### PR TITLE
support crc64 check and img attr set

### DIFF
--- a/src/main/java/com/aliyun/oss/OSS.java
+++ b/src/main/java/com/aliyun/oss/OSS.java
@@ -60,6 +60,7 @@ import com.aliyun.oss.model.GenerateVodPlaylistRequest;
 import com.aliyun.oss.model.GenericRequest;
 import com.aliyun.oss.model.GetBucketImageResult;
 import com.aliyun.oss.model.GetBucketReplicationProgressRequest;
+import com.aliyun.oss.model.ImageProcessConf;
 import com.aliyun.oss.model.ListLiveChannelsRequest;
 import com.aliyun.oss.model.LiveChannel;
 import com.aliyun.oss.model.LiveChannelGenericRequest;
@@ -68,6 +69,7 @@ import com.aliyun.oss.model.LiveChannelListing;
 import com.aliyun.oss.model.LiveChannelStat;
 import com.aliyun.oss.model.LiveChannelStatus;
 import com.aliyun.oss.model.LiveRecord;
+import com.aliyun.oss.model.PutImageProcessConfRequest;
 import com.aliyun.oss.model.ReplicationRule;
 import com.aliyun.oss.model.GetImageStyleResult;
 import com.aliyun.oss.model.GetObjectRequest;
@@ -880,11 +882,40 @@ public interface OSS {
     /**
      * 列出 {@link Bucket} bucketName下的所有样式
      * @param bucketName
-     * @throws OSSException
-     * @throws ClientException
+     * @throws OSSException OSS Server异常信息。
+     * @throws ClientException OSS Client异常信息。
      */
     public List<Style> listImageStyle(String bucketName, GenericRequest genericRequest) 
     		throws OSSException, ClientException;
+    
+    /**
+     * 创建图片处理属性
+     * @param putImageProcessConfRequest 请求信息。
+     * @throws OSSException OSS Server异常信息。
+     * @throws ClientException OSS Client异常信息。
+     */
+    public void putBucketImageProcessConf(PutImageProcessConfRequest putImageProcessConfRequest)
+            throws OSSException, ClientException;
+    
+    /**
+     * 读取图片处理属性
+     * @param bucketName Bucket名称。
+     * @return 图片处理属性
+     * @throws OSSException OSS Server异常信息。
+     * @throws ClientException OSS Client异常信息。
+     */
+    public ImageProcessConf getBucketImageProcessConf(String bucketName)
+            throws OSSException, ClientException;
+    
+    /**
+     * 读取图片处理属性    
+     * @param genericRequest 请求信息。
+     * @return 图片处理属性
+     * @throws OSSException OSS Server异常信息。
+     * @throws ClientException OSS Client异常信息。
+     */
+    public ImageProcessConf getBucketImageProcessConf(GenericRequest genericRequest) 
+            throws OSSException, ClientException;
 
     /**
      * 初始化一个Multipart上传事件。

--- a/src/main/java/com/aliyun/oss/OSSClient.java
+++ b/src/main/java/com/aliyun/oss/OSSClient.java
@@ -103,6 +103,7 @@ import com.aliyun.oss.model.GenerateVodPlaylistRequest;
 import com.aliyun.oss.model.GenericRequest;
 import com.aliyun.oss.model.GetBucketImageResult;
 import com.aliyun.oss.model.GetBucketReplicationProgressRequest;
+import com.aliyun.oss.model.ImageProcessConf;
 import com.aliyun.oss.model.ListLiveChannelsRequest;
 import com.aliyun.oss.model.LiveChannel;
 import com.aliyun.oss.model.LiveChannelGenericRequest;
@@ -111,6 +112,7 @@ import com.aliyun.oss.model.LiveChannelListing;
 import com.aliyun.oss.model.LiveChannelStat;
 import com.aliyun.oss.model.LiveChannelStatus;
 import com.aliyun.oss.model.LiveRecord;
+import com.aliyun.oss.model.PutImageProcessConfRequest;
 import com.aliyun.oss.model.ReplicationRule;
 import com.aliyun.oss.model.GetImageStyleResult;
 import com.aliyun.oss.model.GetObjectRequest;
@@ -1013,6 +1015,24 @@ public class OSSClient implements OSS {
     		throws OSSException, ClientException {
             return bucketOperation.listImageStyle(bucketName, genericRequest);
     }
+	
+	@Override
+    public void putBucketImageProcessConf(PutImageProcessConfRequest putImageProcessConfRequest)
+            throws OSSException, ClientException {
+	    bucketOperation.putBucketImageProcessConf(putImageProcessConfRequest);
+	}
+    
+	@Override
+    public ImageProcessConf getBucketImageProcessConf(String bucketName)
+            throws OSSException, ClientException {
+	    return this.getBucketImageProcessConf(new GenericRequest(bucketName));
+	}
+    
+	@Override
+    public ImageProcessConf getBucketImageProcessConf(GenericRequest genericRequest) 
+            throws OSSException, ClientException {
+	    return bucketOperation.getBucketImageProcessConf(genericRequest);
+	}
 
     @Override
     public void setBucketWebsite(SetBucketWebsiteRequest setBucketWebSiteRequest)

--- a/src/main/java/com/aliyun/oss/common/comm/RequestChecksumHanlder.java
+++ b/src/main/java/com/aliyun/oss/common/comm/RequestChecksumHanlder.java
@@ -17,38 +17,27 @@
  * under the License.
  */
 
-package com.aliyun.oss.model;
+package com.aliyun.oss.common.comm;
 
-/**
- * A generic result that contains some basic response options, such as requestId.
- */
-public abstract class GenericResult {
-   
-    public String getRequestId() {
-        return requestId;
-    }
+import java.io.InputStream;
+import java.util.zip.CheckedInputStream;
 
-    public void setRequestId(String requestId) {
-        this.requestId = requestId;
-    }
+import com.aliyun.oss.ClientException;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.common.utils.CRC64;
+
+public class RequestChecksumHanlder implements RequestHandler {
     
-    public Long getClientCRC64() {
-        return clientCRC64;
+    @Override
+    public void handle(RequestMessage request) throws OSSException, ClientException {
+        InputStream originalInputStream = request.getContent();
+        if (originalInputStream == null) {
+            return;
+        }
+        
+        CRC64 crc = new CRC64();
+        CheckedInputStream checkedInputstream = new CheckedInputStream(originalInputStream, crc);
+        request.setContent(checkedInputstream);
     }
 
-    public void setClientCRC64(Long clientCRC64) {
-        this.clientCRC64 = clientCRC64;
-    }
-
-    public Long getServerCRC64() {
-        return serverCRC64;
-    }
-
-    public void setServerCRC64(Long serverCRC64) {
-        this.serverCRC64 = serverCRC64;
-    }
-    
-    private String requestId;
-    private Long clientCRC64;
-    private Long serverCRC64;
 }

--- a/src/main/java/com/aliyun/oss/common/comm/ResponseChecksumHandler.java
+++ b/src/main/java/com/aliyun/oss/common/comm/ResponseChecksumHandler.java
@@ -17,38 +17,27 @@
  * under the License.
  */
 
-package com.aliyun.oss.model;
+package com.aliyun.oss.common.comm;
 
-/**
- * A generic result that contains some basic response options, such as requestId.
- */
-public abstract class GenericResult {
-   
-    public String getRequestId() {
-        return requestId;
-    }
+import java.io.InputStream;
+import java.util.zip.CheckedInputStream;
 
-    public void setRequestId(String requestId) {
-        this.requestId = requestId;
-    }
-    
-    public Long getClientCRC64() {
-        return clientCRC64;
-    }
+import com.aliyun.oss.ClientException;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.common.utils.CRC64;
 
-    public void setClientCRC64(Long clientCRC64) {
-        this.clientCRC64 = clientCRC64;
-    }
+public class ResponseChecksumHandler implements ResponseHandler {
 
-    public Long getServerCRC64() {
-        return serverCRC64;
+    @Override
+    public void handle(ResponseMessage response) throws OSSException, ClientException {
+        InputStream originalInputStream = response.getContent();
+        if (originalInputStream == null) {
+            return;
+        }
+        
+        CRC64 crc = new CRC64();
+        CheckedInputStream checkedInputstream = new CheckedInputStream(originalInputStream, crc);
+        response.setContent(checkedInputstream);
     }
 
-    public void setServerCRC64(Long serverCRC64) {
-        this.serverCRC64 = serverCRC64;
-    }
-    
-    private String requestId;
-    private Long clientCRC64;
-    private Long serverCRC64;
 }

--- a/src/main/java/com/aliyun/oss/common/parser/RequestMarshallers.java
+++ b/src/main/java/com/aliyun/oss/common/parser/RequestMarshallers.java
@@ -36,6 +36,7 @@ import com.aliyun.oss.model.CreateBucketRequest;
 import com.aliyun.oss.model.CreateLiveChannelRequest;
 import com.aliyun.oss.model.DeleteBucketCnameRequest;
 import com.aliyun.oss.model.DeleteObjectsRequest;
+import com.aliyun.oss.model.ImageProcessConf;
 import com.aliyun.oss.model.LifecycleRule;
 import com.aliyun.oss.model.LifecycleRule.AbortMultipartUpload;
 import com.aliyun.oss.model.LifecycleRule.RuleStatus;
@@ -72,7 +73,8 @@ public final class RequestMarshallers {
     public static final SetBucketLifecycleRequestMarshaller setBucketLifecycleRequestMarshaller = new SetBucketLifecycleRequestMarshaller();
 	public static final PutBucketImageRequestMarshaller putBucketImageRequestMarshaller = new PutBucketImageRequestMarshaller();
 	public static final PutImageStyleRequestMarshaller putImageStyleRequestMarshaller = new PutImageStyleRequestMarshaller();
-    public static final SetBucketCORSRequestMarshaller setBucketCORSRequestMarshaller = new SetBucketCORSRequestMarshaller();
+	public static final BucketImageProcessConfMarshaller bucketImageProcessConfMarshaller = new BucketImageProcessConfMarshaller();
+	public static final SetBucketCORSRequestMarshaller setBucketCORSRequestMarshaller = new SetBucketCORSRequestMarshaller();
     public static final SetBucketTaggingRequestMarshaller setBucketTaggingRequestMarshaller = new SetBucketTaggingRequestMarshaller();
     public static final AddBucketReplicationRequestMarshaller addBucketReplicationRequestMarshaller = new AddBucketReplicationRequestMarshaller();
     public static final DeleteBucketReplicationRequestMarshaller deleteBucketReplicationRequestMarshaller = new DeleteBucketReplicationRequestMarshaller();    
@@ -121,6 +123,27 @@ public final class RequestMarshallers {
 	        return stringMarshaller.marshall(xmlBody.toString());
 		}
 	}
+	
+    public static final class BucketImageProcessConfMarshaller implements RequestMarshaller<ImageProcessConf> {
+
+        @Override
+        public FixedLengthInputStream marshall(ImageProcessConf imageProcessConf) {
+            StringBuffer xmlBody = new StringBuffer();
+            xmlBody.append("<BucketProcessConfiguration>");
+            xmlBody.append("<CompliedHost>" + imageProcessConf.getCompliedHost() + "</CompliedHost>");
+            if (imageProcessConf.isSourceFileProtect() ) {
+                xmlBody.append("<SourceFileProtect>Enabled</SourceFileProtect>");
+            } else {
+                xmlBody.append("<SourceFileProtect>Disabled</SourceFileProtect>");
+            }
+            xmlBody.append("<SourceFileProtectSuffix>" + imageProcessConf.getSourceFileProtectSuffix() 
+                    + "</SourceFileProtectSuffix>");
+            xmlBody.append("<StyleDelimiters>" + imageProcessConf.getStyleDelimiters() + "</StyleDelimiters>");
+            xmlBody.append("</BucketProcessConfiguration>");
+            return stringMarshaller.marshall(xmlBody.toString());
+        }
+        
+    }
 
 	public static final class PutBucketImageRequestMarshaller  implements RequestMarshaller<PutBucketImageRequest> {
 		@Override

--- a/src/main/java/com/aliyun/oss/common/utils/CRC64.java
+++ b/src/main/java/com/aliyun/oss/common/utils/CRC64.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.aliyun.oss.common.utils;
+
+import java.util.zip.Checksum;
+
+/**
+ * CRC-64 implementation with ability to combine checksums calculated over different blocks of data.
+ * Standard ECMA-182, http://www.ecma-international.org/publications/standards/Ecma-182.htm
+ */
+public class CRC64 implements Checksum {
+
+    private final static long POLY = (long) 0xc96c5795d7870f42L; // ECMA-182
+
+    /* CRC64 calculation table. */
+    private final static long[] table;
+
+    /* Current CRC value. */
+    private long value;
+
+    static {
+        table = new long[256];
+
+        for (int n = 0; n < 256; n++) {
+            long crc = n;
+            for (int k = 0; k < 8; k++) {
+                if ((crc & 1) == 1) {
+                    crc = (crc >>> 1) ^ POLY;
+                } else {
+                    crc = (crc >>> 1);
+                }
+            }
+            table[n] = crc;
+        }
+    }
+
+    public CRC64() {
+        this.value = 0;
+    }
+
+    public CRC64(long value) {
+        this.value = value;
+    }
+
+    public CRC64(byte [] b, int len) {
+        this.value = 0;
+        update(b, len);
+    }
+
+    /**
+     * Construct new CRC64 instance from byte array.
+     **/
+    public static CRC64 fromBytes(byte [] b) {
+        long l = 0;
+        for (int i = 0; i < 4; i++) {
+            l <<= 8;
+            l ^= (long) b[i] & 0xFF;
+        }
+        return new CRC64(l);
+    }
+
+    /**
+     * Get 8 byte representation of current CRC64 value.
+     **/
+    public byte[] getBytes() {
+        byte [] b = new byte[8];
+        for (int i = 0; i < 8; i++) {
+            b[7 - i] = (byte) (this.value >>> (i * 8));
+        }
+        return b;
+    }
+
+    /**
+     * Get long representation of current CRC64 value.
+     **/
+    @Override
+    public long getValue() {
+        return this.value;
+    }
+
+    /**
+     * Update CRC64 with new byte block.
+     **/
+    public void update(byte [] b, int len) {
+        int idx = 0;
+        this.value = ~this.value;
+        while (len > 0) {
+            this.value = table[((int) (this.value ^ b[idx])) & 0xff] ^ (this.value >>> 8);
+            idx++;
+            len--;
+        }
+        this.value = ~this.value;
+    }
+    
+    /**
+     * Update CRC64 with new byte.
+     **/
+    public void update(byte b) {
+        this.value = ~this.value;
+        this.value = table[((int) (this.value ^ b)) & 0xff] ^ (this.value >>> 8);
+        this.value = ~this.value;
+    }
+    
+    @Override
+    public void update(int b) {
+        update((byte) (b & 0xFF));
+    }
+
+    @Override
+    public void update(byte[] b, int off, int len) {
+        for (int i = off; len > 0; len--) {
+            update(b[i++]);
+        }
+    }
+
+    @Override
+    public void reset() {
+        this.value = 0;
+    }
+
+    private static final int GF2_DIM = 64; /* dimension of GF(2) vectors (length of CRC) */
+
+    private static long gf2MatrixTimes(long [] mat, long vec)
+    {
+        long sum = 0;
+        int idx = 0;
+        while (vec != 0) {
+            if ((vec & 1) == 1)
+                sum ^= mat[idx];
+            vec >>>= 1;
+            idx++;
+        }
+        return sum;
+    }
+
+    private static void gf2MatrixSquare(long [] square, long [] mat)
+    {
+        for (int n = 0; n < GF2_DIM; n++)
+            square[n] = gf2MatrixTimes(mat, mat[n]);
+    }
+
+    /*
+     * Return the CRC-64 of two sequential blocks, where summ1 is the CRC-64 of the
+     * first block, summ2 is the CRC-64 of the second block, and len2 is the length
+     * of the second block.
+     */
+    static public CRC64 combine(CRC64 summ1, CRC64 summ2, long len2)
+    {
+        // degenerate case.
+        if (len2 == 0)
+            return new CRC64(summ1.getValue());
+
+        int n;
+        long row;
+        long [] even = new long[GF2_DIM]; // even-power-of-two zeros operator
+        long [] odd  = new long[GF2_DIM];  // odd-power-of-two zeros operator
+
+        // put operator for one zero bit in odd
+        odd[0] = POLY;      // CRC-64 polynomial
+
+        row = 1;
+        for (n = 1; n < GF2_DIM; n++) {
+            odd[n] = row;
+            row <<= 1;
+        }
+
+        // put operator for two zero bits in even
+        gf2MatrixSquare(even, odd);
+
+        // put operator for four zero bits in odd
+        gf2MatrixSquare(odd, even);
+
+        // apply len2 zeros to crc1 (first square will put the operator for one
+        // zero byte, eight zero bits, in even)
+        long crc1 = summ1.getValue();
+        long crc2 = summ2.getValue();
+        do {
+            // apply zeros operator for this bit of len2
+            gf2MatrixSquare(even, odd);
+            if ((len2 & 1) == 1)
+                crc1 = gf2MatrixTimes(even, crc1);
+            len2 >>>= 1;
+
+            // if no more bits set, then done
+            if (len2 == 0)
+                break;
+
+            // another iteration of the loop with odd and even swapped
+            gf2MatrixSquare(odd, even);
+            if ((len2 & 1) == 1)
+                crc1 = gf2MatrixTimes(odd, crc1);
+            len2 >>>= 1;
+
+            // if no more bits set, then done
+        } while (len2 != 0);
+
+        // return combined crc.
+        crc1 ^= crc2;
+        return new CRC64(crc1);
+    }
+    
+    /*
+     * Return the CRC-64 of two sequential blocks, where summ1 is the CRC-64 of the
+     * first block, summ2 is the CRC-64 of the second block, and len2 is the length
+     * of the second block.
+     */
+    static public long combine(long crc1, long crc2, long len2)
+    {
+        // degenerate case.
+        if (len2 == 0)
+            return crc1;
+
+        int n;
+        long row;
+        long [] even = new long[GF2_DIM]; // even-power-of-two zeros operator
+        long [] odd  = new long[GF2_DIM];  // odd-power-of-two zeros operator
+
+        // put operator for one zero bit in odd
+        odd[0] = POLY;      // CRC-64 polynomial
+
+        row = 1;
+        for (n = 1; n < GF2_DIM; n++) {
+            odd[n] = row;
+            row <<= 1;
+        }
+
+        // put operator for two zero bits in even
+        gf2MatrixSquare(even, odd);
+
+        // put operator for four zero bits in odd
+        gf2MatrixSquare(odd, even);
+
+        // apply len2 zeros to crc1 (first square will put the operator for one
+        // zero byte, eight zero bits, in even)
+        do {
+            // apply zeros operator for this bit of len2
+            gf2MatrixSquare(even, odd);
+            if ((len2 & 1) == 1)
+                crc1 = gf2MatrixTimes(even, crc1);
+            len2 >>>= 1;
+
+            // if no more bits set, then done
+            if (len2 == 0)
+                break;
+
+            // another iteration of the loop with odd and even swapped
+            gf2MatrixSquare(odd, even);
+            if ((len2 & 1) == 1)
+                crc1 = gf2MatrixTimes(odd, crc1);
+            len2 >>>= 1;
+
+            // if no more bits set, then done
+        } while (len2 != 0);
+
+        // return combined crc.
+        crc1 ^= crc2;
+        return crc1;
+    }
+
+}

--- a/src/main/java/com/aliyun/oss/common/utils/IOUtils.java
+++ b/src/main/java/com/aliyun/oss/common/utils/IOUtils.java
@@ -31,6 +31,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.zip.CheckedInputStream;
 
 import com.aliyun.oss.common.comm.io.BoundedInputStream;
 import com.aliyun.oss.common.comm.io.RepeatableBoundedFileInputStream;
@@ -151,6 +152,13 @@ public class IOUtils {
             repeatable = original;
         }
         return repeatable;
+    }
+    
+    public static Long getCRC64Value(InputStream inputStream) {
+        if (inputStream instanceof CheckedInputStream) {
+            return ((CheckedInputStream) inputStream).getChecksum().getValue();
+        }
+        return null;
     }
     
 }

--- a/src/main/java/com/aliyun/oss/internal/OSSBucketOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSBucketOperation.java
@@ -32,6 +32,7 @@ import static com.aliyun.oss.common.parser.RequestMarshallers.deleteBucketReplic
 import static com.aliyun.oss.common.parser.RequestMarshallers.addBucketCnameRequestMarshaller;
 import static com.aliyun.oss.common.parser.RequestMarshallers.deleteBucketCnameRequestMarshaller;
 import static com.aliyun.oss.common.parser.RequestMarshallers.setBucketQosRequestMarshaller;
+import static com.aliyun.oss.common.parser.RequestMarshallers.bucketImageProcessConfMarshaller;
 import static com.aliyun.oss.common.utils.CodingUtils.assertParameterNotNull;
 import static com.aliyun.oss.internal.OSSUtils.ensureBucketNameValid;
 import static com.aliyun.oss.internal.RequestParameters.DELIMITER;
@@ -50,6 +51,7 @@ import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_REFERER;
 import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_STYLE;
 import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_TAGGING;
 import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_WEBSITE;
+import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_PROCESS_CONF;
 import static com.aliyun.oss.internal.ResponseParsers.getBucketAclResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.getBucketLifecycleResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.getBucketLocationResponseParser;
@@ -68,6 +70,7 @@ import static com.aliyun.oss.internal.ResponseParsers.listObjectsReponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.getBucketImageResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.getImageStyleResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.listImageStyleResponseParser;
+import static com.aliyun.oss.internal.ResponseParsers.getBucketImageProcessConfResponseParser;
 
 import java.io.ByteArrayInputStream;
 import java.util.HashMap;
@@ -100,6 +103,8 @@ import com.aliyun.oss.model.DeleteBucketReplicationRequest;
 import com.aliyun.oss.model.GenericRequest;
 import com.aliyun.oss.model.GetBucketImageResult;
 import com.aliyun.oss.model.GetBucketReplicationProgressRequest;
+import com.aliyun.oss.model.ImageProcessConf;
+import com.aliyun.oss.model.PutImageProcessConfRequest;
 import com.aliyun.oss.model.ReplicationRule;
 import com.aliyun.oss.model.GetImageStyleResult;
 import com.aliyun.oss.model.LifecycleRule;
@@ -503,7 +508,6 @@ public class OSSBucketOperation extends OSSOperation {
     /**
      * put image style
      */
-    
     public void putImageStyle(PutImageStyleRequest putImageStyleRequest)
     		throws OSSException, ClientException {
     	assertParameterNotNull(putImageStyleRequest, "putImageStyleRequest");
@@ -591,6 +595,56 @@ public class OSSBucketOperation extends OSSOperation {
 		        .build();
         
         return doOperation(request, listImageStyleResponseParser, bucketName, null, true);
+    }
+    
+    public void putBucketImageProcessConf(PutImageProcessConfRequest putImageProcessConfRequest)
+            throws OSSException, ClientException {
+        
+        assertParameterNotNull(putImageProcessConfRequest, "putImageProcessConfRequest");
+        
+        ImageProcessConf imageProcessConf = putImageProcessConfRequest.getImageProcessConf();
+        assertParameterNotNull(imageProcessConf, "imageProcessConf");
+        
+        String bucketName = putImageProcessConfRequest.getBucketName();
+        assertParameterNotNull(bucketName, "bucketName");
+        ensureBucketNameValid(bucketName);
+        
+        Map<String, String> params = new HashMap<String, String>();
+        params.put(SUBRESOURCE_PROCESS_CONF, null);
+        
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient())
+                .setEndpoint(getEndpoint())
+                .setMethod(HttpMethod.PUT)
+                .setBucket(bucketName)
+                .setParameters(params)
+                .setInputStreamWithLength(bucketImageProcessConfMarshaller.marshall(imageProcessConf))
+                .setOriginalRequest(putImageProcessConfRequest)
+                .build();
+        
+        doOperation(request, emptyResponseParser, bucketName, null);
+    }
+    
+    public ImageProcessConf getBucketImageProcessConf(GenericRequest genericRequest) 
+            throws OSSException, ClientException {
+
+        assertParameterNotNull(genericRequest, "genericRequest");
+        
+        String bucketName = genericRequest.getBucketName();
+        assertParameterNotNull(bucketName, "bucketName");
+        ensureBucketNameValid(bucketName);
+
+        Map<String, String> params = new HashMap<String, String>();
+        params.put(SUBRESOURCE_PROCESS_CONF, null);
+
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient())
+                .setEndpoint(getEndpoint())
+                .setMethod(HttpMethod.GET)
+                .setBucket(bucketName)
+                .setParameters(params)
+                .setOriginalRequest(genericRequest)
+                .build();
+        
+        return doOperation(request, getBucketImageProcessConfResponseParser , bucketName, null, true);
     }
     
     /**

--- a/src/main/java/com/aliyun/oss/internal/OSSOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSOperation.java
@@ -35,9 +35,11 @@ import com.aliyun.oss.common.auth.CredentialsProvider;
 import com.aliyun.oss.common.auth.RequestSigner;
 import com.aliyun.oss.common.comm.ExecutionContext;
 import com.aliyun.oss.common.comm.NoRetryStrategy;
+import com.aliyun.oss.common.comm.RequestChecksumHanlder;
 import com.aliyun.oss.common.comm.RequestHandler;
 import com.aliyun.oss.common.comm.RequestMessage;
 import com.aliyun.oss.common.comm.RequestProgressHanlder;
+import com.aliyun.oss.common.comm.ResponseChecksumHandler;
 import com.aliyun.oss.common.comm.ResponseHandler;
 import com.aliyun.oss.common.comm.ResponseMessage;
 import com.aliyun.oss.common.comm.ResponseProgressHandler;
@@ -126,17 +128,20 @@ public abstract class OSSOperation {
             request.addHeader(OSSHeaders.OSS_SECURITY_TOKEN, context.getCredentials().getSecurityToken());
         }
         
+        
         context.addRequestHandler(new RequestProgressHanlder());
         if (requestHandlers != null) {
             for (RequestHandler handler : requestHandlers)
                 context.addRequestHandler(handler);
         }
+        context.addRequestHandler(new RequestChecksumHanlder());
         
         context.addResponseHandler(new ResponseProgressHandler(originalRequest));
         if (reponseHandlers != null) {
             for (ResponseHandler handler : reponseHandlers)
                 context.addResponseHandler(handler);
         }
+        context.addResponseHandler(new ResponseChecksumHandler());
         
         ResponseMessage response = send(request, context, keepResponseOpen);
         

--- a/src/main/java/com/aliyun/oss/internal/RequestParameters.java
+++ b/src/main/java/com/aliyun/oss/internal/RequestParameters.java
@@ -47,7 +47,9 @@ public final class RequestParameters {
     public static final String SUBRESOURCE_VOD = "vod";
     public static final String SUBRESOURCE_START_TIME = "startTime";
     public static final String SUBRESOURCE_END_TIME = "endTime";
-
+    public static final String SUBRESOURCE_PROCESS_CONF = "processConfiguration";
+    public static final String SUBRESOURCE_PROCESS = "x-oss-process";
+    
     public static final String PREFIX = "prefix";
     public static final String DELIMITER = "delimiter";
     public static final String MARKER = "marker";    

--- a/src/main/java/com/aliyun/oss/internal/SignUtils.java
+++ b/src/main/java/com/aliyun/oss/internal/SignUtils.java
@@ -49,6 +49,8 @@ import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_STATUS;
 import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_VOD;
 import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_START_TIME;
 import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_END_TIME;
+import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_PROCESS_CONF;
+import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_PROCESS;
 import static com.aliyun.oss.internal.RequestParameters.UPLOAD_ID;
 import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_QOS;
 import static com.aliyun.oss.model.ResponseHeaderOverrides.RESPONSE_HEADER_CACHE_CONTROL;
@@ -84,7 +86,8 @@ public class SignUtils {
             SUBRESOURCE_REPLICATION_LOCATION, SUBRESOURCE_CNAME, 
             SUBRESOURCE_BUCKET_INFO, SUBRESOURCE_COMP, SUBRESOURCE_QOS,
             SUBRESOURCE_LIVE, SUBRESOURCE_STATUS, SUBRESOURCE_VOD, 
-            SUBRESOURCE_START_TIME, SUBRESOURCE_END_TIME,
+            SUBRESOURCE_START_TIME, SUBRESOURCE_END_TIME, SUBRESOURCE_PROCESS,
+            SUBRESOURCE_PROCESS_CONF, 
     });
     
     public static String buildCanonicalString(String method, String resourcePath,

--- a/src/main/java/com/aliyun/oss/model/AppendObjectRequest.java
+++ b/src/main/java/com/aliyun/oss/model/AppendObjectRequest.java
@@ -25,7 +25,8 @@ import java.io.InputStream;
 public class AppendObjectRequest extends PutObjectRequest {
     
     private Long position;
-    
+    private Long previousCRC64;
+
     public AppendObjectRequest(String bucketName, String key, File file) {
         this(bucketName, key, file, null);
     }
@@ -50,8 +51,21 @@ public class AppendObjectRequest extends PutObjectRequest {
         this.position = position;
     }
     
+    public Long getPreviousCRC64() {
+        return previousCRC64;
+    }
+
+    public void setPreviousCRC64(Long previousCRC64) {
+        this.previousCRC64 = previousCRC64;
+    }
+    
     public AppendObjectRequest withPosition(Long position) {
         setPosition(position);
+        return this;
+    }
+    
+    public AppendObjectRequest withPreviousCRC64(Long previousCRC64) {
+        setPreviousCRC64(previousCRC64);
         return this;
     }
     

--- a/src/main/java/com/aliyun/oss/model/ImageProcessConf.java
+++ b/src/main/java/com/aliyun/oss/model/ImageProcessConf.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.aliyun.oss.model;
+
+public class ImageProcessConf {
+
+    public ImageProcessConf(String compliedHost, boolean sourceFileProtect,
+            String sourceFileProtectSuffix, String styleDelimiters) {
+        this.compliedHost = compliedHost;
+        this.sourceFileProtect = sourceFileProtect;
+        this.sourceFileProtectSuffix = sourceFileProtectSuffix;
+        this.styleDelimiters = styleDelimiters;
+    }
+
+    public String getCompliedHost() {
+        return compliedHost;
+    }
+
+    public void setCompliedHost(String compliedHost) {
+        this.compliedHost = compliedHost;
+    }
+
+    public boolean isSourceFileProtect() {
+        return sourceFileProtect;
+    }
+
+    public void setSourceFileProtect(boolean sourceFileProtect) {
+        this.sourceFileProtect = sourceFileProtect;
+    }
+
+    public String getSourceFileProtectSuffix() {
+        return sourceFileProtectSuffix;
+    }
+
+    public void setSourceFileProtectSuffix(String sourceFileProtectSuffix) {
+        this.sourceFileProtectSuffix = sourceFileProtectSuffix;
+    }
+
+    public String getStyleDelimiters() {
+        return styleDelimiters;
+    }
+
+    public void setStyleDelimiters(String styleDelimiters) {
+        this.styleDelimiters = styleDelimiters;
+    }
+
+    private String compliedHost;
+    private boolean sourceFileProtect;
+    private String sourceFileProtectSuffix;
+    private String styleDelimiters;
+}

--- a/src/main/java/com/aliyun/oss/model/PartETag.java
+++ b/src/main/java/com/aliyun/oss/model/PartETag.java
@@ -29,8 +29,9 @@ public class PartETag implements Serializable {
     private static final long serialVersionUID = 2471854027355307627L;
 
     private int partNumber;
-
     private String eTag;
+    private long partSize;
+    private Long partCRC64;
 
     /**
      * 构造函数。
@@ -42,6 +43,24 @@ public class PartETag implements Serializable {
     public PartETag(int partNumber, String eTag) {
         this.partNumber = partNumber;
         this.eTag = eTag;
+    }
+    
+    /**
+     * 构造函数。
+     * @param partNumber
+     *          Part标识号码。
+     * @param eTag
+     *          Part的ETag值。
+     * @param partSize
+     *          分片大小。
+     * @param partCRC64
+     *          分片的CRC64值。       
+     */
+    public PartETag(int partNumber, String eTag, long partSize, Long partCRC64) {
+        this.partNumber = partNumber;
+        this.eTag = eTag;
+        this.partSize = partSize;
+        this.partCRC64 = partCRC64;
     }
 
     /**
@@ -76,6 +95,22 @@ public class PartETag implements Serializable {
      */
     public void setETag(String eTag) {
         this.eTag = eTag;
+    }
+    
+    public long getPartSize() {
+        return partSize;
+    }
+
+    public void setPartSize(long partSize) {
+        this.partSize = partSize;
+    }
+
+    public Long getPartCRC64() {
+        return partCRC64;
+    }
+
+    public void setPartCRC64(Long partCRC64) {
+        this.partCRC64 = partCRC64;
     }
     
     @Override

--- a/src/main/java/com/aliyun/oss/model/PutImageProcessConfRequest.java
+++ b/src/main/java/com/aliyun/oss/model/PutImageProcessConfRequest.java
@@ -19,36 +19,20 @@
 
 package com.aliyun.oss.model;
 
-/**
- * A generic result that contains some basic response options, such as requestId.
- */
-public abstract class GenericResult {
-   
-    public String getRequestId() {
-        return requestId;
-    }
-
-    public void setRequestId(String requestId) {
-        this.requestId = requestId;
+public class PutImageProcessConfRequest extends GenericRequest {
+    
+    public PutImageProcessConfRequest(String bucketName, ImageProcessConf imageProcessConf) {
+        super(bucketName);
+        this.imageProcessConf = imageProcessConf;
     }
     
-    public Long getClientCRC64() {
-        return clientCRC64;
+    public ImageProcessConf getImageProcessConf() {
+        return imageProcessConf;
     }
 
-    public void setClientCRC64(Long clientCRC64) {
-        this.clientCRC64 = clientCRC64;
+    public void setImageProcessConf(ImageProcessConf imageProcessConf) {
+        this.imageProcessConf = imageProcessConf;
     }
 
-    public Long getServerCRC64() {
-        return serverCRC64;
-    }
-
-    public void setServerCRC64(Long serverCRC64) {
-        this.serverCRC64 = serverCRC64;
-    }
-    
-    private String requestId;
-    private Long clientCRC64;
-    private Long serverCRC64;
+    private ImageProcessConf imageProcessConf;
 }

--- a/src/main/java/com/aliyun/oss/model/UploadPartResult.java
+++ b/src/main/java/com/aliyun/oss/model/UploadPartResult.java
@@ -26,7 +26,7 @@ package com.aliyun.oss.model;
 public class UploadPartResult extends GenericResult {
 
     private int partNumber;
-
+    private long partSize;
     private String eTag;
 
     /**
@@ -84,6 +84,23 @@ public class UploadPartResult extends GenericResult {
      * @return 包含Part标识号码和ETag值的{@link PartETag}对象。
      */
     public PartETag getPartETag() {
-        return new PartETag(partNumber, eTag);
+        return new PartETag(partNumber, eTag, partSize, getClientCRC64());
     }
+    
+    /**
+     * 返回分片大小
+     * @return 分片大小
+     */
+    public long getPartSize() {
+        return partSize;
+    }
+
+    /**
+     * 设置分片大小
+     * @param partSize 分片大小
+     */
+    public void setPartSize(long partSize) {
+        this.partSize = partSize;
+    }
+    
 }

--- a/src/test/java/com/aliyun/oss/integrationtests/BucketImageProcessConfTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/BucketImageProcessConfTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.aliyun.oss.integrationtests;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import com.aliyun.oss.OSSErrorCode;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.model.GenericRequest;
+import com.aliyun.oss.model.ImageProcessConf;
+import com.aliyun.oss.model.PutImageProcessConfRequest;
+
+public class BucketImageProcessConfTest extends TestBase {
+
+    @Test
+    public void testBucketImageProcessConf() {
+        try {      
+            // get default
+            ImageProcessConf conf = secondClient.getBucketImageProcessConf(bucketName);
+            Assert.assertEquals(conf.getCompliedHost(), "Both");
+            Assert.assertFalse(conf.isSourceFileProtect());
+            Assert.assertEquals(conf.getSourceFileProtectSuffix(), "");
+            Assert.assertEquals(conf.getStyleDelimiters(), "");
+            
+            // put 1
+            conf = new ImageProcessConf("Img", true, "jpg,png", "/,-");
+            PutImageProcessConfRequest request = new PutImageProcessConfRequest(bucketName, conf);
+            secondClient.putBucketImageProcessConf(request);
+            
+            // get 1
+            conf = secondClient.getBucketImageProcessConf(new GenericRequest(bucketName));
+            Assert.assertEquals(conf.getCompliedHost(), "Img");
+            Assert.assertTrue(conf.isSourceFileProtect());
+            Assert.assertEquals(conf.getSourceFileProtectSuffix(), "jpg,png");
+            Assert.assertEquals(conf.getStyleDelimiters(), "-,/");
+            
+            // put 2
+            conf = new ImageProcessConf("Both", false, "gif", "-");
+            request = new PutImageProcessConfRequest(bucketName, conf);
+            secondClient.putBucketImageProcessConf(request);
+            
+            // get 2
+            conf = secondClient.getBucketImageProcessConf(new GenericRequest(bucketName));
+            Assert.assertEquals(conf.getCompliedHost(), "Both");
+            Assert.assertFalse(conf.isSourceFileProtect());
+            Assert.assertEquals(conf.getSourceFileProtectSuffix(), "");
+            Assert.assertEquals(conf.getStyleDelimiters(), "-");
+            
+            // put 3
+            conf = new ImageProcessConf("Img", true, "*", "/");
+            request = new PutImageProcessConfRequest(bucketName, conf);
+            secondClient.putBucketImageProcessConf(request);
+            
+            // get 3
+            conf = secondClient.getBucketImageProcessConf(new GenericRequest(bucketName));
+            Assert.assertEquals(conf.getCompliedHost(), "Img");
+            Assert.assertTrue(conf.isSourceFileProtect());
+            Assert.assertEquals(conf.getSourceFileProtectSuffix(), "*");
+            Assert.assertEquals(conf.getStyleDelimiters(), "/");
+            
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testBucketImageProcessConfNegative() {
+        // bucket not exist
+        try {
+            secondClient.getBucketImageProcessConf("bucket-not-exist");
+            Assert.fail("GetBucketImageProcessConf should not be successful.");
+        } catch (OSSException e) {
+            Assert.assertEquals(OSSErrorCode.NO_SUCH_BUCKET, e.getErrorCode());
+        }
+        
+        try {
+            ImageProcessConf conf = new ImageProcessConf("img", false, "*", "/,-");
+            PutImageProcessConfRequest request = new PutImageProcessConfRequest("bucket-not-exist", conf);
+            secondClient.putBucketImageProcessConf(request);
+            Assert.fail("PutBucketImageProcessConf should not be successful.");
+        } catch (OSSException e) {
+            Assert.assertEquals(OSSErrorCode.NO_SUCH_BUCKET, e.getErrorCode());
+        }
+        
+        // parameter invalid
+        try {
+            ImageProcessConf conf = null;
+            PutImageProcessConfRequest request = new PutImageProcessConfRequest(bucketName, conf);
+            secondClient.putBucketImageProcessConf(request);
+            Assert.fail("PutBucketImageProcessConf should not be successful.");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NullPointerException);
+        }
+        
+        try {
+            ImageProcessConf conf = new ImageProcessConf(null, false, "*", "/,-");
+            PutImageProcessConfRequest request = new PutImageProcessConfRequest(bucketName, conf);
+            secondClient.putBucketImageProcessConf(request);
+            Assert.fail("PutBucketImageProcessConf should not be successful.");
+        } catch (OSSException e) {
+            Assert.assertEquals(OSSErrorCode.INVALID_ARGUMENT, e.getErrorCode());
+        }
+        
+        try {
+            ImageProcessConf conf = new ImageProcessConf("xxx", false, "*", "/,-");
+            PutImageProcessConfRequest request = new PutImageProcessConfRequest(bucketName, conf);
+            secondClient.putBucketImageProcessConf(request);
+            Assert.fail("PutBucketImageProcessConf should not be successful.");
+        } catch (OSSException e) {
+            Assert.assertEquals(OSSErrorCode.INVALID_ARGUMENT, e.getErrorCode());
+        }
+    }
+
+}

--- a/src/test/java/com/aliyun/oss/integrationtests/CRCChecksumTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/CRCChecksumTest.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.aliyun.oss.integrationtests;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import com.aliyun.oss.common.utils.IOUtils;
+import com.aliyun.oss.model.AppendObjectRequest;
+import com.aliyun.oss.model.AppendObjectResult;
+import com.aliyun.oss.model.CompleteMultipartUploadRequest;
+import com.aliyun.oss.model.CompleteMultipartUploadResult;
+import com.aliyun.oss.model.GenericResult;
+import com.aliyun.oss.model.GetObjectRequest;
+import com.aliyun.oss.model.InitiateMultipartUploadRequest;
+import com.aliyun.oss.model.InitiateMultipartUploadResult;
+import com.aliyun.oss.model.OSSObject;
+import com.aliyun.oss.model.PartETag;
+import com.aliyun.oss.model.PutObjectResult;
+import com.aliyun.oss.model.UploadPartRequest;
+import com.aliyun.oss.model.UploadPartResult;
+
+public class CRCChecksumTest extends TestBase {
+    
+    @Test
+    public void testPutObjectCRC64() {
+        String key = "put-object-crc";
+        String content = "Hello OSS, Hi OSS, OSS OK.";
+        
+        try {
+            // 测试字符串上传
+            PutObjectResult putObjectResult = secondClient.putObject(bucketName, key, 
+                    new ByteArrayInputStream(content.getBytes()));
+            checkCRC(putObjectResult);
+            secondClient.deleteObject(bucketName, key);
+            
+            // 测试文件上传
+            File file = createSampleFile(key, 1024 * 500);
+            putObjectResult = secondClient.putObject(bucketName, key, file);
+            checkCRC(putObjectResult);
+            secondClient.deleteObject(bucketName, key);
+            file.delete();
+            
+            // 测试文件流上传
+            file = createSampleFile(key, 1024 * 1000);
+            putObjectResult = secondClient.putObject(bucketName, key, new FileInputStream(file));
+            checkCRC(putObjectResult);
+            secondClient.deleteObject(bucketName, key);
+            file.delete();
+            
+            // 测试网络流上传
+            InputStream inputStream = new URL("https://www.aliyun.com/product/oss").openStream();
+            putObjectResult = secondClient.putObject(bucketName, key, inputStream);
+            checkCRC(putObjectResult);
+            secondClient.deleteObject(bucketName, key);
+            
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testAppendObjectCRC64() {
+        String key = "append-object-crc";
+        String content = "Hello OSS, Hi OSS.";
+        
+        try {
+            AppendObjectRequest appendObjectRequest = new AppendObjectRequest(bucketName, key, 
+                    new ByteArrayInputStream(content.getBytes())).withPosition(0L);
+            
+            // 第一次追加
+            appendObjectRequest.setPreviousCRC64(0L);
+            AppendObjectResult appendObjectResult = secondClient.appendObject(appendObjectRequest);
+            checkCRC(appendObjectResult);
+            
+            // 第二次追加，合并有问题，客户端计算的CRC是本次上传的，但是服务器返回的是object的
+            appendObjectRequest = new AppendObjectRequest(bucketName, key, new ByteArrayInputStream(content.getBytes()));
+            appendObjectRequest.setPosition(appendObjectResult.getNextPosition());
+            appendObjectRequest.setPreviousCRC64(appendObjectResult.getClientCRC64());
+            appendObjectResult = secondClient.appendObject(appendObjectRequest);
+            checkCRC(appendObjectResult);
+            
+            // 第三次追加
+            appendObjectRequest = new AppendObjectRequest(bucketName, key, new ByteArrayInputStream(content.getBytes()));
+            appendObjectRequest.setPosition(appendObjectResult.getNextPosition());
+            appendObjectRequest.setPreviousCRC64(appendObjectResult.getClientCRC64());
+            appendObjectResult = secondClient.appendObject(appendObjectRequest);
+            checkCRC(appendObjectResult);
+            
+            secondClient.deleteObject(bucketName, key);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testMutilUploadCRC64() {
+        String key = "mutil-upload-object-crc";
+        
+        try {
+            List<PartETag> partETags = new ArrayList<PartETag>();
+            
+            // 初始化上传任务
+            InitiateMultipartUploadRequest initiateMultipartUploadRequest = 
+                    new InitiateMultipartUploadRequest(bucketName, key);
+            InitiateMultipartUploadResult initiateMultipartUploadResult = 
+                    secondClient.initiateMultipartUpload(initiateMultipartUploadRequest);
+            String uploadId = initiateMultipartUploadResult.getUploadId();
+
+            // 上传分片
+            for (int i = 0; i < 5 ; i++) {
+                long fileLen = 1024 * 100 * (i + 1);
+                String filePath = TestUtils.genFixedLengthFile(fileLen);
+                UploadPartRequest request = new UploadPartRequest(bucketName, key, uploadId, i + 1, 
+                        new FileInputStream(filePath), fileLen);
+                UploadPartResult uploadPartResult = secondClient.uploadPart(request);
+                partETags.add(uploadPartResult.getPartETag());
+                checkCRC(uploadPartResult);
+            }
+            
+            // 提交上传任务，服务器返回整个文件的CRC，客户端没有计算
+            CompleteMultipartUploadRequest CompleteMultipartUploadRequest = 
+                    new CompleteMultipartUploadRequest(bucketName, key, uploadId, partETags); 
+            CompleteMultipartUploadResult completeMultipartUploadResult =
+                    secondClient.completeMultipartUpload(CompleteMultipartUploadRequest);
+            checkCRC(completeMultipartUploadResult);
+            
+            secondClient.deleteObject(bucketName, key);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testGetObjectCRC64() {
+        String key = "get-object-crc";
+
+        try {
+            InputStream inputStream = TestUtils.genFixedLengthInputStream(1024 * 100);
+            PutObjectResult putObjectResult = secondClient.putObject(bucketName, key, inputStream);
+            checkCRC(putObjectResult);
+            
+            OSSObject ossObject = secondClient.getObject(bucketName, key);
+            Assert.assertNull(ossObject.getClientCRC64());
+            Assert.assertNotNull(ossObject.getServerCRC64());
+            
+            InputStream content = ossObject.getObjectContent();
+            while (content.read() != -1) {
+            }
+            
+            ossObject.setClientCRC64(IOUtils.getCRC64Value(content));
+            checkCRC(ossObject);
+            content.close();
+            
+            // 范围CRC上不支持
+            GetObjectRequest getObjectRequest = new GetObjectRequest(bucketName, key);
+            getObjectRequest.setRange(100, 10000);
+            OSSObject ossRangeObject = secondClient.getObject(getObjectRequest);
+            Assert.assertNull(ossRangeObject.getClientCRC64());
+            Assert.assertNotNull(ossRangeObject.getServerCRC64());
+            Assert.assertEquals(ossObject.getServerCRC64(), ossRangeObject.getServerCRC64());
+                        
+            secondClient.deleteObject(bucketName, key);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+
+    }
+    
+    @Test
+    public void testEmpytObjectCRC64() {
+        String key = "empty-object-crc";
+
+        try {
+            // put
+            PutObjectResult putObjectResult = secondClient.putObject(bucketName, key,
+                    new ByteArrayInputStream(new String("").getBytes()));
+            Assert.assertTrue(putObjectResult.getClientCRC64() == 0L);
+            Assert.assertTrue(putObjectResult.getServerCRC64() == 0L);
+            
+            String localFile = TestUtils.genFixedLengthFile(0);
+            putObjectResult = secondClient.putObject(bucketName, key, new FileInputStream(localFile));
+            Assert.assertEquals(putObjectResult.getClientCRC64(), putObjectResult.getServerCRC64());
+            Assert.assertTrue(putObjectResult.getClientCRC64() == 0L);
+            Assert.assertTrue(putObjectResult.getServerCRC64() == 0L);
+            
+            putObjectResult = secondClient.putObject(bucketName, key, new File(localFile));
+            Assert.assertEquals(putObjectResult.getClientCRC64(), putObjectResult.getServerCRC64());
+            Assert.assertTrue(putObjectResult.getClientCRC64() == 0L);
+            Assert.assertTrue(putObjectResult.getServerCRC64() == 0L);
+
+            // get
+            OSSObject ossObject = secondClient.getObject(bucketName, key);
+            Assert.assertNull(ossObject.getClientCRC64());
+            Assert.assertNotNull(ossObject.getServerCRC64());
+            
+            Assert.assertTrue(IOUtils.getCRC64Value(ossObject.getObjectContent()) == 0L);
+            
+            InputStream content = ossObject.getObjectContent();
+            while (content.read() != -1) {
+            }
+
+            ossObject.setClientCRC64(IOUtils.getCRC64Value(content));
+            Assert.assertTrue(putObjectResult.getClientCRC64() == 0L);
+            Assert.assertTrue(putObjectResult.getServerCRC64() == 0L);
+            content.close();
+            
+            secondClient.deleteObject(bucketName, key);
+            TestUtils.removeFile(localFile);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
+    
+    private static <Result extends GenericResult>  void checkCRC(final Result result) {
+        Assert.assertNotNull(result.getClientCRC64());
+        Assert.assertNotNull(result.getServerCRC64());
+        Assert.assertTrue(result.getClientCRC64() != 0L);
+        Assert.assertTrue(result.getServerCRC64() != 0L);
+        Assert.assertEquals(result.getClientCRC64(), result.getServerCRC64());
+    }
+    
+}


### PR DESCRIPTION
添加如下功能：
1. CRC64校验。上传、追加、分片上传、下载支持CRC64校验，边上传/下载数据边计算CRC64。
2. 添加两个接口putBucketImageProcessConf、getBucketImageProcessConf，添加签名字段x-oss-process支持oss和img合并。
3. rtmp的id改成name。