### PR TITLE
fix 2.2.3 bugs

### DIFF
--- a/src/main/java/com/aliyun/oss/OSSClient.java
+++ b/src/main/java/com/aliyun/oss/OSSClient.java
@@ -21,6 +21,7 @@ package com.aliyun.oss;
 
 import static com.aliyun.oss.common.utils.CodingUtils.assertParameterNotNull;
 import static com.aliyun.oss.common.utils.IOUtils.checkFile;
+import static com.aliyun.oss.common.utils.LogUtils.logException;
 import static com.aliyun.oss.internal.OSSConstants.DEFAULT_CHARSET_NAME;
 import static com.aliyun.oss.internal.OSSConstants.DEFAULT_OSS_ENDPOINT;
 import static com.aliyun.oss.internal.OSSUtils.OSS_RESOURCE_MANAGER;
@@ -1411,6 +1412,7 @@ public class OSSClient implements OSS {
         try {
             serviceClient.shutdown();
         } catch(Exception e) {
+            logException("shutdown throw exception: ", e);
         }
     }
     

--- a/src/main/java/com/aliyun/oss/OSSClient.java
+++ b/src/main/java/com/aliyun/oss/OSSClient.java
@@ -1408,7 +1408,10 @@ public class OSSClient implements OSS {
     
     @Override
     public void shutdown() {
-        serviceClient.shutdown();
+        try {
+            serviceClient.shutdown();
+        } catch(Exception e) {
+        }
     }
     
 }

--- a/src/main/java/com/aliyun/oss/common/comm/DefaultServiceClient.java
+++ b/src/main/java/com/aliyun/oss/common/comm/DefaultServiceClient.java
@@ -46,6 +46,7 @@ import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -93,6 +94,7 @@ public class DefaultServiceClient extends ServiceClient {
             String proxyDomain = config.getProxyDomain();
             String proxyWorkstation = config.getProxyWorkstation();
             if (proxyUsername != null && proxyPassword != null){
+                this.credentialsProvider = new BasicCredentialsProvider();
                 this.credentialsProvider.setCredentials(new AuthScope(proxyHost, proxyPort),
                         new NTCredentials(proxyUsername, proxyPassword, proxyWorkstation, proxyDomain));
             }

--- a/src/main/java/com/aliyun/oss/internal/OSSBucketOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSBucketOperation.java
@@ -245,11 +245,15 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addOptionalACLHeader(headers, setBucketAclRequest.getCannedACL());
         
+        Map<String, String> params = new HashMap<String, String>();
+        params.put(SUBRESOURCE_ACL, null);
+        
         RequestMessage request = new OSSRequestMessageBuilder(getInnerClient())
                 .setEndpoint(getEndpoint())
                 .setMethod(HttpMethod.PUT)
                 .setBucket(bucketName)
                 .setHeaders(headers)
+                .setParameters(params)
                 .setOriginalRequest(setBucketAclRequest)
                 .build();
         

--- a/src/main/java/com/aliyun/oss/internal/OSSMultipartOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSMultipartOperation.java
@@ -49,6 +49,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -155,6 +157,14 @@ public class OSSMultipartOperation extends OSSOperation {
         
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.put(UPLOAD_ID, uploadId);
+        
+        List<PartETag> partETags = completeMultipartUploadRequest.getPartETags();
+        Collections.sort(partETags, new Comparator<PartETag>() {
+            @Override
+            public int compare(PartETag p1, PartETag p2) {
+                return p1.getPartNumber() - p2.getPartNumber();
+            }
+        });
         
         RequestMessage request = new OSSRequestMessageBuilder(getInnerClient())
                 .setEndpoint(getEndpoint())

--- a/src/test/java/com/aliyun/oss/OSSClientRequestTest.java
+++ b/src/test/java/com/aliyun/oss/OSSClientRequestTest.java
@@ -561,13 +561,15 @@ public class OSSClientRequestTest {
     public void testCompleteMultipartUploadRequest(){
         String uploadId = "upload123";
         List<PartETag> partETags = new LinkedList<PartETag>();
-        partETags.add(new PartETag(1, "PART1ABCD"));
         partETags.add(new PartETag(2, "PART2ABCD"));
+        partETags.add(new PartETag(1, "PART1ABCD"));
+        partETags.add(new PartETag(3, "PART3ABCD"));
         final CompleteMultipartUploadRequest request =
                 new CompleteMultipartUploadRequest(bucketName, objectKey, uploadId, partETags);
         String requestXml = "<CompleteMultipartUpload>"
                 + "<Part><PartNumber>1</PartNumber><ETag>&quot;PART1ABCD&quot;</ETag></Part>"
                 + "<Part><PartNumber>2</PartNumber><ETag>&quot;PART2ABCD&quot;</ETag></Part>"
+                + "<Part><PartNumber>3</PartNumber><ETag>&quot;PART3ABCD&quot;</ETag></Part>"
                 + "</CompleteMultipartUpload>";
 
         TestAction test1 = new TestAction(){

--- a/src/test/java/com/aliyun/oss/common/comm/OSSClientTest.java
+++ b/src/test/java/com/aliyun/oss/common/comm/OSSClientTest.java
@@ -29,6 +29,7 @@ import java.util.Date;
 
 import org.junit.Test;
 
+import com.aliyun.oss.ClientConfiguration;
 import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.model.GeneratePresignedUrlRequest;
 
@@ -63,6 +64,22 @@ public class OSSClientTest {
         request.setContentMD5("md5");
         url = client.generatePresignedUrl(request);
         assertTrue(!url.getQuery().equals("Expires=1422720000&OSSAccessKeyId=id&Signature=XA8ThdVKdJQ4vlkoggdzCs5s1RY%3D"));
+    }
+    
+    @Test
+    public void testProxyHost() {
+        String endpoint = "http://oss-cn-hangzhou.aliyuncs.com";
+        String accessKeyId = "accessKeyId";
+        String accessKeySecret = "accessKeySecret";
+
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setProxyHost(endpoint);
+        conf.setProxyPort(80);
+        conf.setProxyUsername("user");
+        conf.setProxyPassword("passwd");
+
+        OSSClient ossClient = new OSSClient(endpoint, accessKeyId, accessKeySecret, conf);
+        ossClient.shutdown();
     }
 }
 

--- a/src/test/java/com/aliyun/oss/integrationtests/BucketAclTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/BucketAclTest.java
@@ -79,19 +79,16 @@ public class BucketAclTest extends TestBase {
     
     @Test
     public void testUnormalSetBucketAcl() {
-        final String bucketName = "unormal-set-bucket-acl";
+        final String nonexistentBucket = "unormal-set-bucket-acl";
         
-        try {
-            ossClient.createBucket(bucketName);
-            
-            // Set non-existent bucket
-            final String nonexistentBucket = "unormal-set-bucket-acl";
+        try {            
+            // set non-existent bucket
             try {
                 ossClient.setBucketAcl(nonexistentBucket, CannedAccessControlList.Private);
-                // TODO: Why not failed with NO_SUCK_BUCKET error code ?
                 //Assert.fail("Set bucket acl should not be successful");
-            } catch (Exception e) {
-                Assert.fail(e.getMessage());
+            } catch (OSSException e) {
+                Assert.assertEquals(OSSErrorCode.NO_SUCH_BUCKET, e.getErrorCode());
+                Assert.assertTrue(e.getMessage().startsWith(NO_SUCH_BUCKET_ERR));
             }
             
             // Set bucket without ownership
@@ -115,7 +112,7 @@ public class BucketAclTest extends TestBase {
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         } finally {
-            ossClient.deleteBucket(bucketName);
+            ossClient.deleteBucket(nonexistentBucket);
         }
     }
     
@@ -155,4 +152,5 @@ public class BucketAclTest extends TestBase {
             ossClient.deleteBucket(bucketUsingDefaultAcl);
         }
     }
+        
 }


### PR DESCRIPTION
修复3个bug：
1.  分片上传提交时不在要求PartETags是顺序的，completeMultipartUpload自动排序，然后提交；
2. OSSClient.shutdown会抛出InterruptedException，抛该异常是正常的，添加try catch防止抛给用户；
3. 使用setProxyHost是会core，参加https://github.com/aliyun/aliyun-oss-java-sdk/issues/19