### PR TITLE
修复getObjectMetadata的空指针异常

### DIFF
--- a/src/main/java/com/aliyun/oss/model/ObjectMetadata.java
+++ b/src/main/java/com/aliyun/oss/model/ObjectMetadata.java
@@ -118,7 +118,8 @@ public class ObjectMetadata {
      * @throws ParseException 无法将Expires解析为Rfc822格式，抛出该异常。
      */
     public Date getExpirationTime() throws ParseException {
-        return DateUtil.parseRfc822Date((String)metadata.get(OSSHeaders.EXPIRES));
+        String expiresValue = getRawExpiresValue();
+        return expiresValue == null ? null : DateUtil.parseRfc822Date(expiresValue);
     }
     
     /**


### PR DESCRIPTION
如果Object没有定义过期时间，因没有判空会出现空指针异常。