### PR TITLE
Fix image mirror replication

### DIFF
--- a/src/main/java/com/aliyun/oss/InconsistentException.java
+++ b/src/main/java/com/aliyun/oss/InconsistentException.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.aliyun.oss;
+
+/**
+ * <p>
+ * 表示OSS端的数据与SDK端的数据不一致。
+ * </p>
+ * 
+ * 
+ * <p>
+ * 通常来讲，调用者需要处理{@link InconsistentException}。因为该异常表明请求被服务处理，
+ * 上传操作已经成功，但是OSS端的数据与SDK端不一致。调用者需要上传上传的文件然后重新删除。
+ * </p>
+ * 
+ * <p>
+ * 抛出该异常的操作包括putObject、appendObject、uploadPart、uploadFile等上传操作，
+ * getObject下载操作的数据一致性，调用者需要在数据流读取结束后校验，即比较OSS端与SDK端的数据校验和。
+ * </p>
+ * 
+ */
+public class InconsistentException extends RuntimeException {
+
+	private static final long serialVersionUID = 2140587868503948665L;
+
+	private Long clientChecksum;
+    private Long serverChecksum;
+    private String requestId;
+
+	public InconsistentException(Long clientChecksum, Long serverChecksum, String requestId) {
+		super();
+		this.clientChecksum = clientChecksum;
+		this.serverChecksum = serverChecksum;
+		this.requestId = requestId;
+	}
+    
+	public Long getClientChecksum() {
+		return clientChecksum;
+	}
+
+	public void setClientChecksum(Long clientChecksum) {
+		this.clientChecksum = clientChecksum;
+	}
+
+	public Long getServerChecksum() {
+		return serverChecksum;
+	}
+
+	public void setServerChecksum(Long serverChecksum) {
+		this.serverChecksum = serverChecksum;
+	}
+
+	public String getRequestId() {
+		return requestId;
+	}
+
+	public void setRequestId(String requestId) {
+		this.requestId = requestId;
+	}
+   
+	@Override
+    public String getMessage() {
+		return "InconsistentException " + "\n[RequestId]: " + getRequestId()
+        + "\n[ClientChecksum]: " + getClientChecksum()
+        + "\n[ServerChecksum]: " + getServerChecksum();
+    }
+	
+}

--- a/src/main/java/com/aliyun/oss/OSSClient.java
+++ b/src/main/java/com/aliyun/oss/OSSClient.java
@@ -71,6 +71,7 @@ import com.aliyun.oss.internal.OSSMultipartOperation;
 import com.aliyun.oss.internal.OSSObjectOperation;
 import com.aliyun.oss.internal.OSSUploadOperation;
 import com.aliyun.oss.internal.OSSUtils;
+import com.aliyun.oss.internal.RequestParameters;
 import com.aliyun.oss.internal.SignUtils;
 import com.aliyun.oss.model.AbortMultipartUploadRequest;
 import com.aliyun.oss.model.AccessControlList;
@@ -786,10 +787,10 @@ public class OSSClient implements OSS {
         requestMessage.setResourcePath(resourcePath);
         
         requestMessage.addHeader(HttpHeaders.DATE, expires);
-        if (request.getContentType() != null && request.getContentType().trim() != "") {
+        if (request.getContentType() != null && !request.getContentType().trim().equals("")) {
             requestMessage.addHeader(HttpHeaders.CONTENT_TYPE, request.getContentType());
         }
-        if (request.getContentMD5() != null && request.getContentMD5().trim() != "") {
+        if (request.getContentMD5() != null && request.getContentMD5().trim().equals("")) {
             requestMessage.addHeader(HttpHeaders.CONTENT_MD5, request.getContentMD5());
         }
         for (Map.Entry<String, String> h : request.getUserMetadata().entrySet()) {
@@ -806,6 +807,10 @@ public class OSSClient implements OSS {
             for (Map.Entry<String, String> entry : request.getQueryParameter().entrySet()) {
                 requestMessage.addParameter(entry.getKey(), entry.getValue());
             }
+        }
+        
+        if (request.getProcess() != null && !request.getProcess().trim().equals("")) {
+        	requestMessage.addParameter(RequestParameters.SUBRESOURCE_PROCESS, request.getProcess());
         }
         
         if (useSecurityToken) {

--- a/src/main/java/com/aliyun/oss/common/parser/RequestMarshallers.java
+++ b/src/main/java/com/aliyun/oss/common/parser/RequestMarshallers.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import com.aliyun.oss.ClientException;
 import com.aliyun.oss.common.comm.io.FixedLengthInputStream;
 import com.aliyun.oss.common.utils.DateUtil;
+import com.aliyun.oss.model.AddBucketReplicationRequest.ReplicationAction;
 import com.aliyun.oss.model.BucketReferer;
 import com.aliyun.oss.model.CompleteMultipartUploadRequest;
 import com.aliyun.oss.model.CreateBucketRequest;
@@ -315,6 +316,18 @@ public final class RequestMarshallers {
                     if (redirect.getMirrorURL() != null) {
                         xmlBody.append("<MirrorURL>" + redirect.getMirrorURL() + "</MirrorURL>");
                     }
+                    if (redirect.getMirrorSecondaryURL() != null) {
+                        xmlBody.append("<MirrorURLSlave>" + redirect.getMirrorSecondaryURL() + "</MirrorURLSlave>");
+                    }
+                    if (redirect.getMirrorProbeURL() != null) {
+                        xmlBody.append("<MirrorURLProbe>" + redirect.getMirrorProbeURL() + "</MirrorURLProbe>");
+                    }
+                    if (redirect.isPassQueryString() != null) {
+                        xmlBody.append("<MirrorPassQueryString>" + redirect.isPassQueryString() + "</MirrorPassQueryString>");
+                    }
+                    if (redirect.isPassOriginalSlashes() != null) {
+                        xmlBody.append("<MirrorPassOriginalSlashes>" + redirect.isPassOriginalSlashes() + "</MirrorPassOriginalSlashes>");
+                    }
                     xmlBody.append("</Redirect>");
                     xmlBody.append("</RoutingRule>");
                 }
@@ -509,6 +522,17 @@ public final class RequestMarshallers {
                 xmlBody.append("<HistoricalObjectReplication>" + "enabled" + "</HistoricalObjectReplication>");
             } else {
                 xmlBody.append("<HistoricalObjectReplication>" + "disabled" + "</HistoricalObjectReplication>");
+            }
+            if (request.getObjectPrefixList() != null && request.getObjectPrefixList().size() > 0) {
+                xmlBody.append("<PrefixSet>");
+                for (String prefix : request.getObjectPrefixList()) {
+                    xmlBody.append("<Prefix>" + prefix + "</Prefix>");
+                }
+                xmlBody.append("</PrefixSet>");
+            }
+            if (request.getReplicationActionList() != null && request.getReplicationActionList().size() > 0) {
+                xmlBody.append("<Action>" + RequestMarshallers.joinRepliationAction(
+                        request.getReplicationActionList()) + "</Action>");
             }
             xmlBody.append("</Rule>");
             xmlBody.append("</ReplicationConfiguration>");
@@ -715,6 +739,22 @@ public final class RequestMarshallers {
         }
         
         return builder.toString();
+    }
+    
+    private static String joinRepliationAction(List <ReplicationAction> actions) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        
+        for (ReplicationAction action : actions) {
+            if (!first) {
+                sb.append(",");
+            }
+            sb.append(action);
+            
+            first = false;
+        }
+
+        return sb.toString();
     }
     
 }

--- a/src/main/java/com/aliyun/oss/common/utils/IOUtils.java
+++ b/src/main/java/com/aliyun/oss/common/utils/IOUtils.java
@@ -154,7 +154,7 @@ public class IOUtils {
         return repeatable;
     }
     
-    public static Long getCRC64Value(InputStream inputStream) {
+    public static Long getCRCValue(InputStream inputStream) {
         if (inputStream instanceof CheckedInputStream) {
             return ((CheckedInputStream) inputStream).getChecksum().getValue();
         }

--- a/src/main/java/com/aliyun/oss/internal/OSSObjectOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSObjectOperation.java
@@ -211,6 +211,11 @@ public class OSSObjectOperation extends OSSOperation {
             Map<String, String> params = new HashMap<String, String>();
             populateResponseHeaderParameters(params, getObjectRequest.getResponseHeaders());
             
+            String process = getObjectRequest.getProcess();
+            if (process != null) {
+            	params.put(RequestParameters.SUBRESOURCE_PROCESS, process);
+            }
+            
             request = new OSSRequestMessageBuilder(getInnerClient())
                     .setEndpoint(getEndpoint())
                     .setMethod(HttpMethod.GET)

--- a/src/main/java/com/aliyun/oss/internal/OSSObjectOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSObjectOperation.java
@@ -135,12 +135,22 @@ public class OSSObjectOperation extends OSSOperation {
      */
     public PutObjectResult putObject(PutObjectRequest putObjectRequest) 
             throws OSSException, ClientException {
+    	
         assertParameterNotNull(putObjectRequest, "putObjectRequest");
+        
+        PutObjectResult result = null;
+        
         if (putObjectRequest.getCallback() == null) {
-            return writeObjectInternal(WriteMode.OVERWRITE, putObjectRequest, putObjectReponseParser);
+            result = writeObjectInternal(WriteMode.OVERWRITE, putObjectRequest, putObjectReponseParser);
         } else {
-            return writeObjectInternal(WriteMode.OVERWRITE, putObjectRequest, putObjectCallbackReponseParser);
+            result = writeObjectInternal(WriteMode.OVERWRITE, putObjectRequest, putObjectCallbackReponseParser);
         }
+        
+        if (getInnerClient().getClientConfiguration().isCrcCheckEnabled()) {
+        	OSSUtils.checkChecksum(result.getClientCRC(), result.getServerCRC(), result.getRequestId());
+        }
+        
+        return result;
     }
     
     /**
@@ -173,12 +183,21 @@ public class OSSObjectOperation extends OSSOperation {
      */
     public AppendObjectResult appendObject(AppendObjectRequest appendObjectRequest) 
             throws OSSException, ClientException {
+    	
         assertParameterNotNull(appendObjectRequest, "appendObjectRequest");
+        
         AppendObjectResult result = writeObjectInternal(WriteMode.APPEND, appendObjectRequest, appendObjectResponseParser); 
-        if (appendObjectRequest.getPreviousCRC64() != null && result.getClientCRC64() != null) {
-            result.setClientCRC64(CRC64.combine(appendObjectRequest.getPreviousCRC64(), result.getClientCRC64(), 
+        
+        if (appendObjectRequest.getInitCRC() != null && result.getClientCRC() != null) {
+            result.setClientCRC(CRC64.combine(appendObjectRequest.getInitCRC(), result.getClientCRC(), 
                     (result.getNextPosition() - appendObjectRequest.getPosition())));
         }
+        
+        if (getInnerClient().getClientConfiguration().isCrcCheckEnabled() && 
+        		appendObjectRequest.getInitCRC() != null) {
+        	OSSUtils.checkChecksum(result.getClientCRC(), result.getServerCRC(), result.getRequestId());
+        }
+        
         return result;
     }
 

--- a/src/main/java/com/aliyun/oss/internal/OSSUtils.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSUtils.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import com.aliyun.oss.ClientConfiguration;
+import com.aliyun.oss.InconsistentException;
 import com.aliyun.oss.common.comm.ResponseMessage;
 import com.aliyun.oss.common.utils.BinaryUtil;
 import com.aliyun.oss.common.utils.CodingUtils;
@@ -468,6 +469,16 @@ public class OSSUtils {
                 headers.put(OSSHeaders.OSS_HEADER_CALLBACK_VAR, base64CbVar);
             }
         }
+    }
+    
+    /**
+     * 检测OSS和SDK计算的校验和是否相同，不同抛异常InconsistentException
+     */
+    public static void checkChecksum(Long clientChecksum, Long serverChecksum, String requestId) {
+    	if (clientChecksum != null && serverChecksum != null && 
+    			!clientChecksum.equals(serverChecksum)) {
+    		throw new InconsistentException(clientChecksum, serverChecksum, requestId);
+    	}
     }
     
 }

--- a/src/main/java/com/aliyun/oss/internal/ResponseParsers.java
+++ b/src/main/java/com/aliyun/oss/internal/ResponseParsers.java
@@ -515,7 +515,7 @@ public final class ResponseParsers {
             try {
                 result.setETag(trimQuotes(response.getHeaders().get(OSSHeaders.ETAG)));
                 result.setRequestId(response.getRequestId());
-                setCRC64(result, response);
+                setCRC(result, response);
                 return result;
             } finally {
                 safeCloseResponse(response);
@@ -550,8 +550,8 @@ public final class ResponseParsers {
                 if (nextPosition != null) {
                     result.setNextPosition(Long.valueOf(nextPosition));                    
                 }
-                result.setObjectCRC64(response.getHeaders().get(OSSHeaders.OSS_HASH_CRC64_ECMA));
-                setCRC64(result, response);
+                result.setObjectCRC(response.getHeaders().get(OSSHeaders.OSS_HASH_CRC64_ECMA));
+                setCRC(result, response);
                 return result;
             } catch (Exception e) {
                 throw new ResponseParseException(e.getMessage(), e);
@@ -581,7 +581,7 @@ public final class ResponseParsers {
             ossObject.setRequestId(response.getRequestId());
             try {
                 ossObject.setObjectMetadata(parseObjectMetadata(response.getHeaders()));
-                setServerCRC64(ossObject, response);
+                setServerCRC(ossObject, response);
                 return ossObject;
             } catch (ResponseParseException e) {
                 // Close response only when parsing exception thrown. Otherwise, 
@@ -684,7 +684,7 @@ public final class ResponseParsers {
             try {
                 CompleteMultipartUploadResult result = parseCompleteMultipartUpload(response.getContent());
                 result.setRequestId(response.getRequestId());
-                setServerCRC64(result, response);
+                setServerCRC(result, response);
                 return result;
             } finally {
                 safeCloseResponse(response);                
@@ -788,27 +788,27 @@ public final class ResponseParsers {
         
     }
     
-    public static <ResultType extends GenericResult> void setCRC64(ResultType result, 
+    public static <ResultType extends GenericResult> void setCRC(ResultType result, 
             ResponseMessage response) {
         InputStream inputStream = response.getRequest().getContent();
         if (inputStream instanceof CheckedInputStream) {
             CheckedInputStream checkedInputStream = (CheckedInputStream)inputStream;
-            result.setClientCRC64(checkedInputStream.getChecksum().getValue());
+            result.setClientCRC(checkedInputStream.getChecksum().getValue());
         }
         
-        String strSrvCrc64 = response.getHeaders().get(OSSHeaders.OSS_HASH_CRC64_ECMA);
-        if (strSrvCrc64 != null) {
-            BigInteger bi = new BigInteger(strSrvCrc64);
-            result.setServerCRC64(bi.longValue());
+        String strSrvCrc = response.getHeaders().get(OSSHeaders.OSS_HASH_CRC64_ECMA);
+        if (strSrvCrc != null) {
+            BigInteger bi = new BigInteger(strSrvCrc);
+            result.setServerCRC(bi.longValue());
         }
     }
     
-    public static <ResultType extends GenericResult> void setServerCRC64(ResultType result, 
+    public static <ResultType extends GenericResult> void setServerCRC(ResultType result, 
             ResponseMessage response) {        
-        String strSrvCrc64 = response.getHeaders().get(OSSHeaders.OSS_HASH_CRC64_ECMA);
-        if (strSrvCrc64 != null) {
-            BigInteger bi = new BigInteger(strSrvCrc64);
-            result.setServerCRC64(bi.longValue());
+        String strSrvCrc = response.getHeaders().get(OSSHeaders.OSS_HASH_CRC64_ECMA);
+        if (strSrvCrc != null) {
+            BigInteger bi = new BigInteger(strSrvCrc);
+            result.setServerCRC(bi.longValue());
         }
     }
     

--- a/src/main/java/com/aliyun/oss/internal/ResponseParsers.java
+++ b/src/main/java/com/aliyun/oss/internal/ResponseParsers.java
@@ -43,6 +43,7 @@ import com.aliyun.oss.common.parser.ResponseParser;
 import com.aliyun.oss.common.utils.DateUtil;
 import com.aliyun.oss.common.utils.HttpUtil;
 import com.aliyun.oss.model.AccessControlList;
+import com.aliyun.oss.model.AddBucketReplicationRequest.ReplicationAction;
 import com.aliyun.oss.model.AppendObjectResult;
 import com.aliyun.oss.model.Bucket;
 import com.aliyun.oss.model.BucketInfo;
@@ -1522,6 +1523,16 @@ public final class ResponseParsers {
                             Integer.parseInt(redirectElem.getChildText("HttpRedirectCode"))); 
                     }
                     rule.getRedirect().setMirrorURL(redirectElem.getChildText("MirrorURL"));
+                    rule.getRedirect().setMirrorSecondaryURL(redirectElem.getChildText("MirrorURLSlave"));
+                    rule.getRedirect().setMirrorProbeURL(redirectElem.getChildText("MirrorURLProbe"));
+                    if (redirectElem.getChildText("MirrorPassQueryString") != null) {
+                        rule.getRedirect().setPassQueryString(Boolean.valueOf(
+                                redirectElem.getChildText("MirrorPassQueryString")));
+                    }
+                    if (redirectElem.getChildText("MirrorPassOriginalSlashes") != null) {
+                        rule.getRedirect().setPassOriginalSlashes(Boolean.valueOf(
+                                redirectElem.getChildText("MirrorPassOriginalSlashes")));
+                    }
                     
                     result.AddRoutingRule(rule);
                 }
@@ -1693,6 +1704,24 @@ public final class ResponseParsers {
                     repRule.setEnableHistoricalObjectReplication(true);
                 } else {
                     repRule.setEnableHistoricalObjectReplication(false);
+                }
+                
+                if (ruleElem.getChild("PrefixSet") != null) {
+                    List<String> objectPrefixes = new ArrayList<String>(); 
+                    List<Element> prefixElems = ruleElem.getChild("PrefixSet").getChildren("Prefix");
+                    for (Element prefixElem : prefixElems) {
+                        objectPrefixes.add(prefixElem.getText());
+                    }
+                    repRule.setObjectPrefixList(objectPrefixes);
+                }
+                
+                if (ruleElem.getChild("Action") != null) {
+                    String[] actionStrs = ruleElem.getChildText("Action").split(",");
+                    List<ReplicationAction> repActions = new ArrayList<ReplicationAction>();
+                    for (String actionStr : actionStrs) {
+                        repActions.add(ReplicationAction.parse(actionStr));
+                    }
+                    repRule.setReplicationActionList(repActions);
                 }
                 
                 repRules.add(repRule);

--- a/src/main/java/com/aliyun/oss/model/AddBucketReplicationRequest.java
+++ b/src/main/java/com/aliyun/oss/model/AddBucketReplicationRequest.java
@@ -19,10 +19,59 @@
 
 package com.aliyun.oss.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * 设置跨区域复制请求。
  */
 public class AddBucketReplicationRequest extends GenericRequest {
+    
+    public static enum ReplicationAction {
+        /**
+         * ALL表示所有操作（PUT、DELETE、ABORT）都复制到目标Bucket，默认动作。
+         */
+        ALL("ALL"),
+        
+        /**
+         * PUT表示所有写入类操作会被复制到目标Bucket，包括PutObject/PostObject/AppendObject/CopyObject/PutObjectACL/
+         * InitiateMultipartUpload/UploadPart/UploadPartCopy/CompleteMultipartUpload。
+         */
+        PUT("PUT"),
+        
+        /**
+         * DELETE表示所有删除类操作会被复制到目标Bucket，包括DeleteObject/DeleteMultipleObjects。
+         */
+        DELETE("DELETE"),
+        
+        /**
+         * ABORT，表示对于未Complete的Upload，AbortMultipartUpload操作会被复制到目标Bucket中。
+         */
+        ABORT("ABORT");
+        
+        private String replicationAction;
+        
+        private ReplicationAction(String replicationAction){
+            this.replicationAction = replicationAction;
+        }
+
+        @Override
+        public String toString() {
+            return this.replicationAction;
+        }
+        
+        public static ReplicationAction parse(String replicationAction) {
+            for(ReplicationAction rt : ReplicationAction.values()) {
+                if (rt.toString().equals(replicationAction)) {
+                    return rt;
+                }
+            }
+            
+            throw new IllegalArgumentException("Unable to parse " + replicationAction);
+        }
+    }
+    
+    
     public AddBucketReplicationRequest(String bucketName) {
         super(bucketName);
     }
@@ -59,9 +108,33 @@ public class AddBucketReplicationRequest extends GenericRequest {
             boolean enableHistoricalObjectReplication) {
         this.enableHistoricalObjectReplication = enableHistoricalObjectReplication;
     }
+    
+    public List<String> getObjectPrefixList() {
+        return objectPrefixList;
+    }
+    
+    public void setObjectPrefixList(List<String> objectPrefixList) {
+        this.objectPrefixList.clear();
+        if (objectPrefixList != null && !objectPrefixList.isEmpty()) {
+            this.objectPrefixList.addAll(objectPrefixList);
+        }
+    }
+    
+    public List<ReplicationAction> getReplicationActionList() {
+        return replicationActionList;
+    }
+    
+    public void setReplicationActionList(List<ReplicationAction> replicationActionList) {
+        this.replicationActionList.clear();
+        if (replicationActionList != null && !replicationActionList.isEmpty()) {
+            this.replicationActionList.addAll(replicationActionList);
+        }
+    }
 
     private String replicationRuleID = "";
     private String targetBucketName;
     private String targetBucketLocation;
     private boolean enableHistoricalObjectReplication = true;
+    private List<String> objectPrefixList = new ArrayList<String>();
+    private List<ReplicationAction> replicationActionList = new ArrayList<ReplicationAction>();
 }

--- a/src/main/java/com/aliyun/oss/model/AppendObjectRequest.java
+++ b/src/main/java/com/aliyun/oss/model/AppendObjectRequest.java
@@ -25,7 +25,7 @@ import java.io.InputStream;
 public class AppendObjectRequest extends PutObjectRequest {
     
     private Long position;
-    private Long previousCRC64;
+    private Long initCRC;
 
     public AppendObjectRequest(String bucketName, String key, File file) {
         this(bucketName, key, file, null);
@@ -51,12 +51,12 @@ public class AppendObjectRequest extends PutObjectRequest {
         this.position = position;
     }
     
-    public Long getPreviousCRC64() {
-        return previousCRC64;
+    public Long getInitCRC() {
+        return initCRC;
     }
 
-    public void setPreviousCRC64(Long previousCRC64) {
-        this.previousCRC64 = previousCRC64;
+    public void setInitCRC(Long iniCRC) {
+        this.initCRC = iniCRC;
     }
     
     public AppendObjectRequest withPosition(Long position) {
@@ -64,8 +64,8 @@ public class AppendObjectRequest extends PutObjectRequest {
         return this;
     }
     
-    public AppendObjectRequest withPreviousCRC64(Long previousCRC64) {
-        setPreviousCRC64(previousCRC64);
+    public AppendObjectRequest withInitCRC(Long iniCRC) {
+        setInitCRC(iniCRC);
         return this;
     }
     

--- a/src/main/java/com/aliyun/oss/model/AppendObjectResult.java
+++ b/src/main/java/com/aliyun/oss/model/AppendObjectResult.java
@@ -29,7 +29,7 @@ public class AppendObjectResult extends GenericResult {
     private Long nextPosition;
     
     /* Returned value of the appended object crc64 */
-    private String objectCRC64;
+    private String objectCRC;
 
     public Long getNextPosition() {
         return nextPosition;
@@ -39,11 +39,11 @@ public class AppendObjectResult extends GenericResult {
         this.nextPosition = nextPosition;
     }
 
-    public String getObjectCRC64() {
-        return objectCRC64;
+    public String getObjectCRC() {
+        return objectCRC;
     }
 
-    public void setObjectCRC64(String objectCRC64) {
-        this.objectCRC64 = objectCRC64;
+    public void setObjectCRC(String objectCRC) {
+        this.objectCRC = objectCRC;
     }
 }

--- a/src/main/java/com/aliyun/oss/model/GeneratePresignedUrlRequest.java
+++ b/src/main/java/com/aliyun/oss/model/GeneratePresignedUrlRequest.java
@@ -44,8 +44,11 @@ public class GeneratePresignedUrlRequest {
 
     /** Content-MD5 */
     private String contentMD5;
+    
+    /** process */
+    private String process;
 
-    /**
+	/**
      * An optional expiration date at which point the generated pre-signed URL
      * will no longer be accepted by OSS. If not specified, a default
      * value will be supplied.
@@ -248,9 +251,14 @@ public class GeneratePresignedUrlRequest {
         this.userMetadata.put(key, value);
     }
 
+    /**
+     * 返回QueryParameter
+     * @return Query Parameter
+     */
     public Map<String,String> getQueryParameter(){
         return this.queryParam;
     }
+    
     /**
      * 用户请求参数，Query String。
      * @param queryParam
@@ -270,5 +278,21 @@ public class GeneratePresignedUrlRequest {
     public void addQueryParameter(String key, String value) {
         this.queryParam.put(key, value);
     }
+    
+    /**
+     * 返回process
+     * @return process
+     */
+    public String getProcess() {
+		return process;
+	}
+
+    /**
+     * 设置process
+     * @param process
+     */
+	public void setProcess(String process) {
+		this.process = process;
+	}
 
 }

--- a/src/main/java/com/aliyun/oss/model/GenericResult.java
+++ b/src/main/java/com/aliyun/oss/model/GenericResult.java
@@ -32,23 +32,23 @@ public abstract class GenericResult {
         this.requestId = requestId;
     }
     
-    public Long getClientCRC64() {
-        return clientCRC64;
+    public Long getClientCRC() {
+        return clientCRC;
     }
 
-    public void setClientCRC64(Long clientCRC64) {
-        this.clientCRC64 = clientCRC64;
+    public void setClientCRC(Long clientCRC) {
+        this.clientCRC = clientCRC;
     }
 
-    public Long getServerCRC64() {
-        return serverCRC64;
+    public Long getServerCRC() {
+        return serverCRC;
     }
 
-    public void setServerCRC64(Long serverCRC64) {
-        this.serverCRC64 = serverCRC64;
+    public void setServerCRC(Long serverCRC) {
+        this.serverCRC = serverCRC;
     }
     
     private String requestId;
-    private Long clientCRC64;
-    private Long serverCRC64;
+    private Long clientCRC;
+    private Long serverCRC;
 }

--- a/src/main/java/com/aliyun/oss/model/GetObjectRequest.java
+++ b/src/main/java/com/aliyun/oss/model/GetObjectRequest.java
@@ -33,8 +33,9 @@ public class GetObjectRequest extends GenericRequest {
     private List<String> nonmatchingEtagConstraints = new ArrayList<String>();
     private Date unmodifiedSinceConstraint;
     private Date modifiedSinceConstraint;
+    private String process;
 
-    private long[] range;
+	private long[] range;
 
     private ResponseHeaderOverrides responseHeaders;
     
@@ -248,4 +249,12 @@ public class GetObjectRequest extends GenericRequest {
         this.useUrlSignature = useUrlSignature;
     }
     
+    public String getProcess() {
+		return process;
+	}
+
+	public void setProcess(String process) {
+		this.process = process;
+	}
+	
 }

--- a/src/main/java/com/aliyun/oss/model/PartETag.java
+++ b/src/main/java/com/aliyun/oss/model/PartETag.java
@@ -31,7 +31,7 @@ public class PartETag implements Serializable {
     private int partNumber;
     private String eTag;
     private long partSize;
-    private Long partCRC64;
+    private Long partCRC;
 
     /**
      * 构造函数。
@@ -53,14 +53,14 @@ public class PartETag implements Serializable {
      *          Part的ETag值。
      * @param partSize
      *          分片大小。
-     * @param partCRC64
-     *          分片的CRC64值。       
+     * @param partCRC
+     *          分片的CRC值。       
      */
-    public PartETag(int partNumber, String eTag, long partSize, Long partCRC64) {
+    public PartETag(int partNumber, String eTag, long partSize, Long partCRC) {
         this.partNumber = partNumber;
         this.eTag = eTag;
         this.partSize = partSize;
-        this.partCRC64 = partCRC64;
+        this.partCRC = partCRC;
     }
 
     /**
@@ -105,12 +105,12 @@ public class PartETag implements Serializable {
         this.partSize = partSize;
     }
 
-    public Long getPartCRC64() {
-        return partCRC64;
+    public Long getPartCRC() {
+        return partCRC;
     }
 
-    public void setPartCRC64(Long partCRC64) {
-        this.partCRC64 = partCRC64;
+    public void setPartCRC(Long partCRC) {
+        this.partCRC = partCRC;
     }
     
     @Override

--- a/src/main/java/com/aliyun/oss/model/ReplicationRule.java
+++ b/src/main/java/com/aliyun/oss/model/ReplicationRule.java
@@ -19,6 +19,11 @@
 
 package com.aliyun.oss.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.aliyun.oss.model.AddBucketReplicationRequest.ReplicationAction;
+
 /**
  * Bucket上已设置的跨区域复制规则。
  */
@@ -64,10 +69,34 @@ public class ReplicationRule {
             boolean enableHistoricalObjectReplication) {
         this.enableHistoricalObjectReplication = enableHistoricalObjectReplication;
     }
+    
+    public List<String> getObjectPrefixList() {
+        return objectPrefixList;
+    }
+    
+    public void setObjectPrefixList(List<String> objectPrefixList) {
+        this.objectPrefixList = new ArrayList<String>();
+        if (objectPrefixList != null && !objectPrefixList.isEmpty()) {
+            this.objectPrefixList.addAll(objectPrefixList);
+        }
+    }
+    
+    public List<ReplicationAction> getReplicationActionList() {
+        return replicationActionList;
+    }
+    
+    public void setReplicationActionList(List<ReplicationAction> replicationActionList) {
+        this.replicationActionList = new ArrayList<ReplicationAction>();
+        if (replicationActionList != null && !replicationActionList.isEmpty()) {
+            this.replicationActionList.addAll(replicationActionList);
+        }
+    }
 
     private String replicationRuleID;
     private ReplicationStatus replicationStatus;
     private String targetBucketName;
     private String targetBucketLocation;
     private boolean enableHistoricalObjectReplication;
+    private List<String> objectPrefixList;
+    private List<ReplicationAction> replicationActionList;
 }

--- a/src/main/java/com/aliyun/oss/model/RoutingRule.java
+++ b/src/main/java/com/aliyun/oss/model/RoutingRule.java
@@ -46,7 +46,11 @@ public class RoutingRule {
             return httpErrorCodeReturnedEquals;
         }
 
-        public void setHttpErrorCodeReturnedEquals(int httpErrorCodeReturnedEquals) {
+        public void setHttpErrorCodeReturnedEquals(Integer httpErrorCodeReturnedEquals) {
+            if (httpErrorCodeReturnedEquals == null) {
+                return;
+            }
+            
             if (httpErrorCodeReturnedEquals <= 0) {
                 throw new IllegalArgumentException(MessageFormat.format("HttpErrorCodeReturnedEqualsInvalid",
                         "HttpErrorCodeReturnedEquals should be greater than 0"));
@@ -74,7 +78,7 @@ public class RoutingRule {
     
     public static enum RedirectType {
         /**
-         * Internal模式暂时不开发
+         * Internal模式尚未支持
          */
         //Internal("Internal"),
         
@@ -192,7 +196,11 @@ public class RoutingRule {
             return httpRedirectCode;
         }
 
-        public void setHttpRedirectCode(int httpRedirectCode) {
+        public void setHttpRedirectCode(Integer httpRedirectCode) {
+            if (httpRedirectCode == null) {
+                return;
+            }
+            
             if (httpRedirectCode < 300 || httpRedirectCode > 399) {
                 throw new IllegalArgumentException(MessageFormat.format("RedirectHttpRedirectCodeInvalid",
                         "HttpRedirectCode must be a valid HTTP 3xx status code."));
@@ -207,6 +215,38 @@ public class RoutingRule {
 
         public void setMirrorURL(String mirrorURL) {
             this.mirrorURL = mirrorURL;
+        }
+        
+        public String getMirrorSecondaryURL() {
+            return mirrorSecondaryURL;
+        }
+
+        public void setMirrorSecondaryURL(String mirrorSecondaryURL) {
+            this.mirrorSecondaryURL = mirrorSecondaryURL;
+        }
+
+        public String getMirrorProbeURL() {
+            return mirrorProbeURL;
+        }
+
+        public void setMirrorProbeURL(String mirrorProbeURL) {
+            this.mirrorProbeURL = mirrorProbeURL;
+        }
+
+        public Boolean isPassQueryString() {
+            return passQueryString;
+        }
+
+        public void setPassQueryString(Boolean passQueryString) {
+            this.passQueryString = passQueryString;
+        }
+
+        public Boolean isPassOriginalSlashes() {
+            return passOriginalSlashes;
+        }
+
+        public void setPassOriginalSlashes(Boolean passOriginalSlashes) {
+            this.passOriginalSlashes = passOriginalSlashes;
         }
         
         /**
@@ -280,13 +320,34 @@ public class RoutingRule {
          * MirrorURL is effective when RedirectType is Mirror
          */
         private String mirrorURL;
+
+        /**
+         * 镜像主备切换的从源站，与MirrorURL的格式要求相同，当主源站访问出错时，OSS会自动切换到此从源站。
+         */
+        private String mirrorSecondaryURL;
+        
+        /**
+         * 镜像主备切换的探测URL，用于探测主源站的连通情况。OSS会周期性的使用HEAD探测此URL，
+         * 如果返回非200，则切换到从源站，否则切换到主源站。
+         */
+        private String mirrorProbeURL;
+        
+        /**
+         * 镜像时是否将请求中的QueryString传递给源站，默认false。
+         */
+        private Boolean passQueryString;
+        
+        /**
+         * 镜像时是否要将OSS请求中host与uri之间多余的斜杠传递给源站，默认false。
+         */
+        private Boolean passOriginalSlashes;
     }
 
     public Integer getNumber() {
         return number;
     }
     
-    public void setNumber(int number) {
+    public void setNumber(Integer number) {
         this.number = number;
     }
     

--- a/src/main/java/com/aliyun/oss/model/StorageClass.java
+++ b/src/main/java/com/aliyun/oss/model/StorageClass.java
@@ -25,14 +25,14 @@ package com.aliyun.oss.model;
 public enum StorageClass {
     
     /**
-     * standard
+     * Standard
      */
     Standard("Standard"),
     
     /**
-     * nearline
+     * Infrequent Access
      */
-    Nearline("Nearline"),
+    IA("IA"),
     
     /**
      * Unknown

--- a/src/main/java/com/aliyun/oss/model/UploadPartResult.java
+++ b/src/main/java/com/aliyun/oss/model/UploadPartResult.java
@@ -84,7 +84,7 @@ public class UploadPartResult extends GenericResult {
      * @return 包含Part标识号码和ETag值的{@link PartETag}对象。
      */
     public PartETag getPartETag() {
-        return new PartETag(partNumber, eTag, partSize, getClientCRC64());
+        return new PartETag(partNumber, eTag, partSize, getClientCRC());
     }
     
     /**

--- a/src/samples/AppendObjectSample.java
+++ b/src/samples/AppendObjectSample.java
@@ -46,7 +46,7 @@ public class AppendObjectSample {
             AppendObjectResult appendObjectResult = client.appendObject(
                     new AppendObjectRequest(bucketName, key, instream).withPosition(0L));
             System.out.println("\tNext position=" + appendObjectResult.getNextPosition() + 
-                    ", CRC64=" + appendObjectResult.getObjectCRC64() + "\n");
+                    ", CRC64=" + appendObjectResult.getObjectCRC() + "\n");
             
             /*
              * Continue to append the object from specfied file descriptor at last position
@@ -57,7 +57,7 @@ public class AppendObjectSample {
                     new AppendObjectRequest(bucketName, key, createTempFile())
                     .withPosition(nextPosition));
             System.out.println("\tNext position=" + appendObjectResult.getNextPosition() + 
-                    ", CRC64=" + appendObjectResult.getObjectCRC64());
+                    ", CRC64=" + appendObjectResult.getObjectCRC());
             
             /*
              * View object type of the appendable object

--- a/src/samples/CRCSample.java
+++ b/src/samples/CRCSample.java
@@ -1,0 +1,96 @@
+package samples;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.aliyun.oss.ClientException;
+import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.model.GetObjectRequest;
+
+/**
+ * 断点续传下载用法示例
+ *
+ */
+public class ImageSample {
+    
+    private static String endpoint = "<endpoint, http://oss-cn-hangzhou.aliyuncs.com>";
+    private static String accessKeyId = "<accessKeyId>";
+    private static String accessKeySecret = "<accessKeySecret>";
+    private static String bucketName = "<bucketName>";
+    private static String key = "example.jpg";
+    
+    
+    public static void main(String[] args) throws IOException {        
+
+        OSSClient ossClient = new OSSClient(endpoint, accessKeyId, accessKeySecret);
+        
+        try {
+            // 缩放
+            String style = "image/resize,m_fixed,w_100,h_100";  
+            GetObjectRequest request = new GetObjectRequest(bucketName, key);
+            request.setProcess(style);
+            
+            ossClient.getObject(request, new File("example-resize.jpg"));
+            
+            // 裁剪
+            style = "image/crop,w_100,h_100,x_100,y_100,r_1"; 
+            request = new GetObjectRequest(bucketName, key);
+            request.setProcess(style);
+            
+            ossClient.getObject(request, new File("example-crop.jpg"));
+            
+            // 旋转
+            style = "image/rotate,90"; 
+            request = new GetObjectRequest(bucketName, key);
+            request.setProcess(style);
+            
+            ossClient.getObject(request, new File("example-rotate.jpg"));
+            
+            // 锐化
+            style = "image/sharpen,100"; 
+            request = new GetObjectRequest(bucketName, key);
+            request.setProcess(style);
+            
+            ossClient.getObject(request, new File("example-sharpen.jpg"));
+            
+            // 水印
+            style = "image/watermark,text_SGVsbG8g5Zu-54mH5pyN5YqhIQ"; 
+            request = new GetObjectRequest(bucketName, key);
+            request.setProcess(style);
+            
+            ossClient.getObject(request, new File("example-watermark.jpg"));
+            
+            // 格式转换
+            style = "image/format,png"; 
+            request = new GetObjectRequest(bucketName, key);
+            request.setProcess(style);
+            
+            ossClient.getObject(request, new File("example-format.png"));
+            
+            // 图片信息
+            style = "image/info"; 
+            request = new GetObjectRequest(bucketName, key);
+            request.setProcess(style);
+            
+            ossClient.getObject(request, new File("example-info.txt"));
+            
+        } catch (OSSException oe) {
+            System.out.println("Caught an OSSException, which means your request made it to OSS, "
+                    + "but was rejected with an error response for some reason.");
+            System.out.println("Error Message: " + oe.getErrorCode());
+            System.out.println("Error Code:       " + oe.getErrorCode());
+            System.out.println("Request ID:      " + oe.getRequestId());
+            System.out.println("Host ID:           " + oe.getHostId());
+        } catch (ClientException ce) {
+            System.out.println("Caught an ClientException, which means the client encountered "
+                    + "a serious internal problem while trying to communicate with OSS, "
+                    + "such as not being able to access the network.");
+            System.out.println("Error Message: " + ce.getMessage());
+        } catch (Throwable e) {
+            e.printStackTrace();
+        } finally {
+            ossClient.shutdown();
+        }
+    }
+}

--- a/src/samples/ImageSample.java
+++ b/src/samples/ImageSample.java
@@ -29,49 +29,49 @@ public class ImageSample {
             // 缩放
             String style = "image/resize,m_fixed,w_100,h_100";  
             GetObjectRequest request = new GetObjectRequest(bucketName, key);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
             
             ossClient.getObject(request, new File("example-resize.jpg"));
             
             // 裁剪
             style = "image/crop,w_100,h_100,x_100,y_100,r_1"; 
             request = new GetObjectRequest(bucketName, key);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
             
             ossClient.getObject(request, new File("example-crop.jpg"));
             
             // 旋转
             style = "image/rotate,90"; 
             request = new GetObjectRequest(bucketName, key);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
             
             ossClient.getObject(request, new File("example-rotate.jpg"));
             
             // 锐化
             style = "image/sharpen,100"; 
             request = new GetObjectRequest(bucketName, key);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
             
             ossClient.getObject(request, new File("example-sharpen.jpg"));
             
             // 水印
             style = "image/watermark,text_SGVsbG8g5Zu-54mH5pyN5YqhIQ"; 
             request = new GetObjectRequest(bucketName, key);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
             
             ossClient.getObject(request, new File("example-watermark.jpg"));
             
             // 格式转换
             style = "image/format,png"; 
             request = new GetObjectRequest(bucketName, key);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
             
             ossClient.getObject(request, new File("example-format.png"));
             
             // 图片信息
             style = "image/info"; 
             request = new GetObjectRequest(bucketName, key);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
             
             ossClient.getObject(request, new File("example-info.txt"));
             

--- a/src/test/java/com/aliyun/oss/integrationtests/BucketReplicationTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/BucketReplicationTest.java
@@ -24,6 +24,7 @@ import static com.aliyun.oss.integrationtests.TestConfig.OSS_TEST_REPLICATION_AC
 import static com.aliyun.oss.integrationtests.TestConfig.OSS_TEST_REPLICATION_ACCESS_KEY_SECRET;
 
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -37,6 +38,7 @@ import org.junit.Test;
 import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.OSSErrorCode;
 import com.aliyun.oss.OSSException;
+import com.aliyun.oss.model.AddBucketReplicationRequest.ReplicationAction;
 import com.aliyun.oss.model.BucketList;
 import com.aliyun.oss.model.BucketReplicationProgress;
 import com.aliyun.oss.model.DeleteBucketReplicationRequest;
@@ -94,6 +96,9 @@ public class BucketReplicationTest extends TestBase {
             Assert.assertEquals(r0.getTargetBucketName(), targetBucketName);
             Assert.assertEquals(r0.getTargetBucketLocation(), targetBucketLoc);
             Assert.assertEquals(r0.getReplicationStatus(), ReplicationStatus.Starting);
+            Assert.assertNull(r0.getObjectPrefixList());
+            Assert.assertEquals(r0.getReplicationActionList().size(), 1);
+            Assert.assertEquals(r0.getReplicationActionList().get(0), ReplicationAction.parse("ALL"));
             
             BucketReplicationProgress progress = ossClient.getBucketReplicationProgress(bucketName, ruleId);
             Assert.assertEquals(progress.getReplicationRuleID(), ruleId);
@@ -192,6 +197,50 @@ public class BucketReplicationTest extends TestBase {
             ossClient.deleteBucketReplication(new DeleteBucketReplicationRequest(bucketName, repRuleID));
                         
         } catch (OSSException e) {
+            Assert.fail(e.getMessage());
+        } finally {
+            ossClient.deleteBucket(bucketName);
+        }
+    }
+    
+    @Test
+    public void testNormalAddBucketReplicationWithAction() throws ParseException {
+        final String bucketName = "test-bucket-replication-action-10";
+
+        try {
+            ossClient.createBucket(bucketName);
+            
+            AddBucketReplicationRequest request = new AddBucketReplicationRequest(bucketName);
+            request.setTargetBucketName(targetBucketName);
+            request.setTargetBucketLocation(targetBucketLoc);
+            
+            List<String> prefixes = new ArrayList<String>();
+            prefixes.add("image/");
+            prefixes.add("video");
+            request.setObjectPrefixList(prefixes);
+            
+            List<ReplicationAction> actions = new ArrayList<ReplicationAction>();
+            actions.add(ReplicationAction.PUT);
+            actions.add(ReplicationAction.DELETE);
+            request.setReplicationActionList(actions);
+            
+            ossClient.addBucketReplication(request);
+                        
+            List<ReplicationRule> rules = ossClient.getBucketReplication(bucketName);
+            Assert.assertEquals(rules.size(), 1);
+            
+            ReplicationRule r0 = rules.get(0);
+            Assert.assertEquals(r0.getReplicationRuleID().length(), "d6a8bfe3-56f6-42dd-9e7f-b4301d99b0ed".length());
+            Assert.assertEquals(r0.getTargetBucketName(), targetBucketName);
+            Assert.assertEquals(r0.getTargetBucketLocation(), targetBucketLoc);
+            Assert.assertEquals(r0.isEnableHistoricalObjectReplication(), true);
+            Assert.assertEquals(r0.getReplicationStatus(), ReplicationStatus.Starting);
+            Assert.assertEquals(r0.getObjectPrefixList().size(), 2);
+            Assert.assertEquals(r0.getReplicationActionList().size(), 2);
+            
+            ossClient.deleteBucketReplication(new DeleteBucketReplicationRequest(bucketName, r0.getReplicationRuleID()));
+        } catch (OSSException e) {
+            e.printStackTrace();
             Assert.fail(e.getMessage());
         } finally {
             ossClient.deleteBucket(bucketName);

--- a/src/test/java/com/aliyun/oss/integrationtests/BucketWebsiteTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/BucketWebsiteTest.java
@@ -138,6 +138,78 @@ public class BucketWebsiteTest extends TestBase {
             Assert.assertEquals(rr.getRedirect().getMirrorURL(), "http://oss-test.aliyun-inc.com/mirror-test/");
             
             ossClient.deleteBucketWebsite(bucketName);
+            
+            // set mirror with secondary default mirror
+            request = new SetBucketWebsiteRequest(bucketName);
+            rule = new RoutingRule();
+            rule.setNumber(2);
+            rule.getCondition().setKeyPrefixEquals("~!@#$%^&*()-_=+|\\[]{}<>,./?`~");
+            rule.getCondition().setHttpErrorCodeReturnedEquals(404);
+            rule.getRedirect().setRedirectType(RoutingRule.RedirectType.Mirror);
+            rule.getRedirect().setMirrorURL("http://oss-test.aliyun-inc.com/mirror-test/");
+            rule.getRedirect().setMirrorSecondaryURL(null);
+            rule.getRedirect().setMirrorProbeURL(null);
+            rule.getRedirect().setPassQueryString(null);
+            rule.getRedirect().setPassOriginalSlashes(null);
+            
+            request.setIndexDocument(indexDocument);
+            request.AddRoutingRule(rule);
+            ossClient.setBucketWebsite(request);
+            
+            waitForCacheExpiration(5);
+            
+            // check
+            result = ossClient.getBucketWebsite(bucketName);
+            Assert.assertEquals(indexDocument, result.getIndexDocument());
+            Assert.assertEquals(result.getRoutingRules().size(), 1);
+            rr = result.getRoutingRules().get(0);
+            Assert.assertEquals(rr.getNumber().intValue(), 2);
+            Assert.assertEquals(rr.getCondition().getKeyPrefixEquals(), "~!@#$%^&*()-_=+|\\[]{}<>,./?`~");
+            Assert.assertEquals(rr.getCondition().getHttpErrorCodeReturnedEquals().intValue(), 404);
+            Assert.assertEquals(rr.getRedirect().getRedirectType(), RoutingRule.RedirectType.Mirror);
+            Assert.assertEquals(rr.getRedirect().getMirrorURL(), "http://oss-test.aliyun-inc.com/mirror-test/");
+            Assert.assertNull(rr.getRedirect().getMirrorSecondaryURL());
+            Assert.assertNull(rr.getRedirect().getMirrorProbeURL());
+            Assert.assertFalse(rr.getRedirect().isPassQueryString());
+            Assert.assertFalse(rr.getRedirect().isPassOriginalSlashes());
+
+            ossClient.deleteBucketWebsite(bucketName);
+            
+            // set mirror with secondary mirror
+            request = new SetBucketWebsiteRequest(bucketName);
+            rule = new RoutingRule();
+            rule.setNumber(2);
+            rule.getCondition().setKeyPrefixEquals("~!@#$%^&*()-_=+|\\[]{}<>,./?`~");
+            rule.getCondition().setHttpErrorCodeReturnedEquals(404);
+            rule.getRedirect().setRedirectType(RoutingRule.RedirectType.Mirror);
+            rule.getRedirect().setMirrorURL("http://oss-test.aliyun-inc.com/mirror-test/");
+            rule.getRedirect().setMirrorSecondaryURL("http://oss-test.aliyun-inc.com/mirror-secodary/");
+            rule.getRedirect().setMirrorProbeURL("http://oss-test.aliyun-inc.com/mirror-probe/");
+            rule.getRedirect().setPassQueryString(true);
+            rule.getRedirect().setPassOriginalSlashes(true);
+            
+            request.setIndexDocument(indexDocument);
+            request.AddRoutingRule(rule);
+            ossClient.setBucketWebsite(request);
+            
+            waitForCacheExpiration(5);
+            
+            // check
+            result = ossClient.getBucketWebsite(bucketName);
+            Assert.assertEquals(indexDocument, result.getIndexDocument());
+            Assert.assertEquals(result.getRoutingRules().size(), 1);
+            rr = result.getRoutingRules().get(0);
+            Assert.assertEquals(rr.getNumber().intValue(), 2);
+            Assert.assertEquals(rr.getCondition().getKeyPrefixEquals(), "~!@#$%^&*()-_=+|\\[]{}<>,./?`~");
+            Assert.assertEquals(rr.getCondition().getHttpErrorCodeReturnedEquals().intValue(), 404);
+            Assert.assertEquals(rr.getRedirect().getRedirectType(), RoutingRule.RedirectType.Mirror);
+            Assert.assertEquals(rr.getRedirect().getMirrorURL(), "http://oss-test.aliyun-inc.com/mirror-test/");
+            Assert.assertEquals(rr.getRedirect().getMirrorSecondaryURL(), "http://oss-test.aliyun-inc.com/mirror-secodary/");
+            Assert.assertEquals(rr.getRedirect().getMirrorProbeURL(), "http://oss-test.aliyun-inc.com/mirror-probe/");
+            Assert.assertTrue(rr.getRedirect().isPassQueryString());
+            Assert.assertTrue(rr.getRedirect().isPassOriginalSlashes());
+            
+            ossClient.deleteBucketWebsite(bucketName);
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail(e.getMessage());

--- a/src/test/java/com/aliyun/oss/integrationtests/CreateBucketTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/CreateBucketTest.java
@@ -235,6 +235,7 @@ public class CreateBucketTest extends TestBase {
             // Create bucket with public-read acl
             createBucketRequest.setCannedACL(CannedAccessControlList.PublicRead);
             ossClient.createBucket(createBucketRequest);
+            waitForCacheExpiration(5);
             returnedAcl = ossClient.getBucketAcl(bucketName);
             grants = returnedAcl.getGrants();
             Assert.assertEquals(1, grants.size());
@@ -302,7 +303,7 @@ public class CreateBucketTest extends TestBase {
         final String bucketName = "bucket-with-storage-type";
         
         CreateBucketRequest createBucketRequest = new CreateBucketRequest(bucketName);
-        createBucketRequest.setStorageClass(StorageClass.Nearline);
+        createBucketRequest.setStorageClass(StorageClass.IA);
         try {
             ossClient.createBucket(createBucketRequest);
             AccessControlList returnedAcl = ossClient.getBucketAcl(bucketName);
@@ -311,7 +312,7 @@ public class CreateBucketTest extends TestBase {
             
             BucketList buckets = ossClient.listBuckets(bucketName, "", 100);
             Assert.assertEquals(1, buckets.getBucketList().size());
-            Assert.assertEquals(StorageClass.Nearline, buckets.getBucketList().get(0).getStorageClass());
+            Assert.assertEquals(StorageClass.IA, buckets.getBucketList().get(0).getStorageClass());
         } catch (Exception ex) {
             Assert.fail(ex.getMessage());
         } finally {
@@ -324,14 +325,14 @@ public class CreateBucketTest extends TestBase {
         final String bucketName = "bucket-with-storage-type-func";
         
         try {
-            ossClient.createBucket(new CreateBucketRequest(bucketName).withStorageType(StorageClass.Nearline));
+            ossClient.createBucket(new CreateBucketRequest(bucketName).withStorageType(StorageClass.IA));
             AccessControlList returnedAcl = ossClient.getBucketAcl(bucketName);
             Set<Grant> grants = returnedAcl.getGrants();
             Assert.assertEquals(0, grants.size());
             
             BucketList buckets = ossClient.listBuckets(bucketName, "", 100);
             Assert.assertEquals(1, buckets.getBucketList().size());
-            Assert.assertEquals(StorageClass.Nearline, buckets.getBucketList().get(0).getStorageClass());
+            Assert.assertEquals(StorageClass.IA, buckets.getBucketList().get(0).getStorageClass());
         } catch (Exception ex) {
             Assert.fail(ex.getMessage());
         } finally {
@@ -377,7 +378,7 @@ public class CreateBucketTest extends TestBase {
             Assert.assertEquals(StorageClass.Standard, buckets.getBucketList().get(0).getStorageClass());
            
             try {
-                createBucketRequest.setStorageClass(StorageClass.Nearline);
+                createBucketRequest.setStorageClass(StorageClass.IA);
                 ossClient.createBucket(createBucketRequest);
                 Assert.fail("Create bucket should not be successful.");
             } catch (OSSException oe) {

--- a/src/test/java/com/aliyun/oss/integrationtests/ImageProcessTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/ImageProcessTest.java
@@ -22,6 +22,8 @@ package com.aliyun.oss.integrationtests;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.util.Date;
 
 import junit.framework.Assert;
 import net.sf.json.JSONObject;
@@ -29,7 +31,10 @@ import net.sf.json.JSONObject;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Test;
 
+import com.aliyun.oss.HttpMethod;
+import com.aliyun.oss.common.utils.DateUtil;
 import com.aliyun.oss.common.utils.IOUtils;
+import com.aliyun.oss.model.GeneratePresignedUrlRequest;
 import com.aliyun.oss.model.GetObjectRequest;
 import com.aliyun.oss.model.OSSObject;
 import com.aliyun.oss.utils.ResourceUtils;
@@ -198,6 +203,32 @@ public class ImageProcessTest extends TestBase {
             Assert.fail(e.getMessage());
         } 
     }
+    
+    @Test
+	public void testGeneratePresignedUrlWithProcess() {
+		String style = "image/resize,m_fixed,w_100,h_100"; // 缩放
+
+		try {
+			Date expiration = DateUtil.parseRfc822Date("Wed, 21 Dec 2022 14:20:00 GMT");
+			GeneratePresignedUrlRequest req = new GeneratePresignedUrlRequest(bucketName, originalImage, HttpMethod.GET);
+			req.setExpiration(expiration);
+			req.setProcess(style);
+
+			URL signedUrl = ossClient.generatePresignedUrl(req);
+			System.out.println(signedUrl);
+
+			OSSObject ossObject = ossClient.getObject(signedUrl, null);
+			ossClient.putObject(bucketName, newImage, ossObject.getObjectContent());
+
+			ImageInfo imageInfo = getImageInfo(bucketName, newImage);
+			Assert.assertEquals(imageInfo.getHeight(), 100);
+			Assert.assertEquals(imageInfo.getWidth(), 100);
+			Assert.assertEquals(imageInfo.getFormat(), "jpg");
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+	}
     
     private static ImageInfo getImageInfo(final String bucket, final String image) throws IOException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
         GetObjectRequest request = new GetObjectRequest(bucketName, image);

--- a/src/test/java/com/aliyun/oss/integrationtests/ImageProcessTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/ImageProcessTest.java
@@ -37,7 +37,7 @@ import com.aliyun.oss.utils.ResourceUtils;
 /**
  * 图片处理服务测试
  */
-public class ImageTest extends TestBase {
+public class ImageProcessTest extends TestBase {
     
     final private static String originalImage = "oss/example.jpg";
     final private static String newImage = "oss/new-example.jpg";
@@ -61,7 +61,7 @@ public class ImageTest extends TestBase {
         
         try {
             GetObjectRequest request = new GetObjectRequest(bucketName, originalImage);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
             
             OSSObject ossObject = ossClient.getObject(request);
             ossClient.putObject(bucketName, newImage, ossObject.getObjectContent());
@@ -83,7 +83,7 @@ public class ImageTest extends TestBase {
         
         try {
             GetObjectRequest request = new GetObjectRequest(bucketName, originalImage);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
             
             OSSObject ossObject = ossClient.getObject(request);
             ossClient.putObject(bucketName, newImage, ossObject.getObjectContent());
@@ -107,7 +107,7 @@ public class ImageTest extends TestBase {
         try {
             GetObjectRequest request = new GetObjectRequest(bucketName,
                     originalImage);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
 
             OSSObject ossObject = ossClient.getObject(request);
             ossClient.putObject(bucketName, newImage, ossObject.getObjectContent());
@@ -136,7 +136,7 @@ public class ImageTest extends TestBase {
 
         try {
             GetObjectRequest request = new GetObjectRequest(bucketName, originalImage);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
 
             OSSObject ossObject = ossClient.getObject(request);
             ossClient.putObject(bucketName, newImage, ossObject.getObjectContent());
@@ -159,7 +159,7 @@ public class ImageTest extends TestBase {
 
         try {
             GetObjectRequest request = new GetObjectRequest(bucketName, originalImage);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
 
             OSSObject ossObject = ossClient.getObject(request);
             ossClient.putObject(bucketName, newImage, ossObject.getObjectContent());
@@ -182,7 +182,7 @@ public class ImageTest extends TestBase {
 
         try {
             GetObjectRequest request = new GetObjectRequest(bucketName, originalImage);
-            request.addParameter("x-oss-process", style);
+            request.setProcess(style);
 
             OSSObject ossObject = ossClient.getObject(request);
             ossClient.putObject(bucketName, newImage, ossObject.getObjectContent());
@@ -201,7 +201,7 @@ public class ImageTest extends TestBase {
     
     private static ImageInfo getImageInfo(final String bucket, final String image) throws IOException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
         GetObjectRequest request = new GetObjectRequest(bucketName, image);
-        request.addParameter("x-oss-process", "image/info");
+        request.setProcess("image/info");
         OSSObject ossObject = ossClient.getObject(request);
         
         String jsonStr = IOUtils.readStreamAsString(ossObject.getObjectContent(), "UTF-8");

--- a/src/test/java/com/aliyun/oss/integrationtests/TestConfig.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/TestConfig.java
@@ -22,17 +22,10 @@ package com.aliyun.oss.integrationtests;
 public final class TestConfig {
 
     // OSS test configuration
-//    public static String OSS_TEST_ENDPOINT = null;
-//    public static String OSS_TEST_REGION = null;
-//    public static String OSS_TEST_ACCESS_KEY_ID = null;
-//    public static String OSS_TEST_ACCESS_KEY_SECRET = null;
-//    public static String OSS_TEST_ACCESS_KEY_ID_1 = null;
-//    public static String OSS_TEST_ACCESS_KEY_SECRET_1 = null;
-
-    public static String OSS_TEST_ENDPOINT = "http://oss-cn-hangzhou.aliyuncs.com";
-    public static String OSS_TEST_REGION = "oss-cn-hangzhou";
-    public static String OSS_TEST_ACCESS_KEY_ID = "vX6ik2aG3MYYnouB";
-    public static String OSS_TEST_ACCESS_KEY_SECRET = "MkvsblmKhReBIETFrfmcm92iI479Yl";
+    public static String OSS_TEST_ENDPOINT = null;
+    public static String OSS_TEST_REGION = null;
+    public static String OSS_TEST_ACCESS_KEY_ID = null;
+    public static String OSS_TEST_ACCESS_KEY_SECRET = null;
     public static String OSS_TEST_ACCESS_KEY_ID_1 = null;
     public static String OSS_TEST_ACCESS_KEY_SECRET_1 = null;
     

--- a/src/test/java/com/aliyun/oss/integrationtests/TestConfig.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/TestConfig.java
@@ -28,7 +28,7 @@ public final class TestConfig {
     public static String OSS_TEST_ACCESS_KEY_SECRET = null;
     public static String OSS_TEST_ACCESS_KEY_ID_1 = null;
     public static String OSS_TEST_ACCESS_KEY_SECRET_1 = null;
-    
+	    
     // OSS replication test configuration
     public static String OSS_TEST_REPLICATION_ENDPOINT = null;
     public static String OSS_TEST_REPLICATION_ACCESS_KEY_ID = null;

--- a/src/test/java/com/aliyun/oss/integrationtests/TestConfig.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/TestConfig.java
@@ -22,10 +22,17 @@ package com.aliyun.oss.integrationtests;
 public final class TestConfig {
 
     // OSS test configuration
-    public static String OSS_TEST_ENDPOINT = null;
-    public static String OSS_TEST_REGION = null;
-    public static String OSS_TEST_ACCESS_KEY_ID = null;
-    public static String OSS_TEST_ACCESS_KEY_SECRET = null;
+//    public static String OSS_TEST_ENDPOINT = null;
+//    public static String OSS_TEST_REGION = null;
+//    public static String OSS_TEST_ACCESS_KEY_ID = null;
+//    public static String OSS_TEST_ACCESS_KEY_SECRET = null;
+//    public static String OSS_TEST_ACCESS_KEY_ID_1 = null;
+//    public static String OSS_TEST_ACCESS_KEY_SECRET_1 = null;
+
+    public static String OSS_TEST_ENDPOINT = "http://oss-cn-hangzhou.aliyuncs.com";
+    public static String OSS_TEST_REGION = "oss-cn-hangzhou";
+    public static String OSS_TEST_ACCESS_KEY_ID = "vX6ik2aG3MYYnouB";
+    public static String OSS_TEST_ACCESS_KEY_SECRET = "MkvsblmKhReBIETFrfmcm92iI479Yl";
     public static String OSS_TEST_ACCESS_KEY_ID_1 = null;
     public static String OSS_TEST_ACCESS_KEY_SECRET_1 = null;
     


### PR DESCRIPTION
- 添加：支持[符号链接](https://help.aliyun.com/document_detail/45126.html)；
- 添加：镜像支持querystring，支持RangGet,支持slash；
- 添加：跨区域复制支持Prefix和Action；
- 修复：图片服务格式，从setparams改成setProcess，两个格式都能使用；
