### PR TITLE
get bucket stat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.aliyun.oss</groupId>
     <artifactId>aliyun-sdk-oss</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Aliyun OSS SDK for Java</name>
     <description>The Aliyun OSS SDK for Java used for accessing Aliyun Object Storage Service</description>

--- a/src/main/java/com/aliyun/oss/OSS.java
+++ b/src/main/java/com/aliyun/oss/OSS.java
@@ -39,6 +39,7 @@ import com.aliyun.oss.model.BucketLoggingResult;
 import com.aliyun.oss.model.BucketProcess;
 import com.aliyun.oss.model.BucketReferer;
 import com.aliyun.oss.model.BucketReplicationProgress;
+import com.aliyun.oss.model.BucketStat;
 import com.aliyun.oss.model.BucketWebsiteResult;
 import com.aliyun.oss.model.CannedAccessControlList;
 import com.aliyun.oss.model.CnameConfiguration;
@@ -1399,6 +1400,26 @@ public interface OSS {
             throws OSSException, ClientException;
     
     /**
+     * 获取{@link Bucket}的存储信息。
+     * @param bucketName 指定Bucket名称。
+     * @return Bucket信息。
+     * @throws OSSException OSS Server异常信息。
+     * @throws ClientException OSS Client异常信息。
+     */
+    public BucketStat getBucketStat(String bucketName)
+            throws OSSException, ClientException;
+    
+    /**
+     * 获取{@link Bucket}的存储信息。
+     * @param genericRequest 请求信息。
+     * @return Bucket信息。
+     * @throws OSSException OSS Server异常信息。
+     * @throws ClientException OSS Client异常信息。
+     */
+    public BucketStat getBucketStat(GenericRequest genericRequest)
+            throws OSSException, ClientException;
+    
+    /**
      * 设置{@link Bucket}的容量。
      * @param bucketName 指定Bucket名称。
      * @param userQos 包括的容量的Bucket Qos。
@@ -1661,7 +1682,7 @@ public interface OSS {
             throws OSSException, ClientException;
 
     /**
-
+	 * 创建符号链接。
      * @param bucketName Bucket名称。
      * @param symlink 符号链接。
      * @param target 目标文件。

--- a/src/main/java/com/aliyun/oss/OSSClient.java
+++ b/src/main/java/com/aliyun/oss/OSSClient.java
@@ -86,6 +86,7 @@ import com.aliyun.oss.model.BucketLoggingResult;
 import com.aliyun.oss.model.BucketProcess;
 import com.aliyun.oss.model.BucketReferer;
 import com.aliyun.oss.model.BucketReplicationProgress;
+import com.aliyun.oss.model.BucketStat;
 import com.aliyun.oss.model.BucketWebsiteResult;
 import com.aliyun.oss.model.CannedAccessControlList;
 import com.aliyun.oss.model.CnameConfiguration;
@@ -1269,6 +1270,18 @@ public class OSSClient implements OSS {
     public BucketInfo getBucketInfo(GenericRequest genericRequest)
             throws OSSException, ClientException {
         return this.bucketOperation.getBucketInfo(genericRequest);
+    }
+    
+    @Override
+    public BucketStat getBucketStat(String bucketName)
+            throws OSSException, ClientException {
+    	return this.getBucketStat(new GenericRequest(bucketName));
+    }
+    
+    @Override
+    public BucketStat getBucketStat(GenericRequest genericRequest)
+            throws OSSException, ClientException {
+    	return this.bucketOperation.getBucketStat(genericRequest);
     }
     
     @Override

--- a/src/main/java/com/aliyun/oss/internal/OSSBucketOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSBucketOperation.java
@@ -64,6 +64,7 @@ import static com.aliyun.oss.internal.ResponseParsers.getBucketReplicationProgre
 import static com.aliyun.oss.internal.ResponseParsers.getBucketReplicationLocationResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.getBucketCnameResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.getBucketInfoResponseParser;
+import static com.aliyun.oss.internal.ResponseParsers.getBucketStatResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.getBucketQosResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.listBucketResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.listObjectsReponseParser;
@@ -95,6 +96,7 @@ import com.aliyun.oss.model.BucketLoggingResult;
 import com.aliyun.oss.model.BucketProcess;
 import com.aliyun.oss.model.BucketReferer;
 import com.aliyun.oss.model.BucketReplicationProgress;
+import com.aliyun.oss.model.BucketStat;
 import com.aliyun.oss.model.BucketWebsiteResult;
 import com.aliyun.oss.model.CannedAccessControlList;
 import com.aliyun.oss.model.CnameConfiguration;
@@ -1209,6 +1211,29 @@ public class OSSBucketOperation extends OSSOperation {
                 .build();
         
         return doOperation(request, getBucketInfoResponseParser, bucketName, null, true);
+    }
+    
+    public BucketStat getBucketStat(GenericRequest genericRequest)
+            throws OSSException, ClientException {
+        
+        assertParameterNotNull(genericRequest, "genericRequest");
+        
+        String bucketName = genericRequest.getBucketName();
+        assertParameterNotNull(bucketName, "bucketName");
+        ensureBucketNameValid(bucketName);
+        
+        Map<String, String> params = new HashMap<String, String>();
+        params.put(RequestParameters.SUBRESOURCE_STAT, null);
+        
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient())
+                .setEndpoint(getEndpoint())
+                .setMethod(HttpMethod.GET)
+                .setBucket(bucketName)
+                .setParameters(params)
+                .setOriginalRequest(genericRequest)
+                .build();
+        
+        return doOperation(request, getBucketStatResponseParser, bucketName, null, true);
     }
     
     public void setBucketStorageCapacity(SetBucketStorageCapacityRequest setBucketStorageCapacityRequest)

--- a/src/main/java/com/aliyun/oss/internal/OSSMultipartOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSMultipartOperation.java
@@ -40,7 +40,7 @@ import static com.aliyun.oss.internal.OSSUtils.trimQuotes;
 import static com.aliyun.oss.internal.OSSConstants.DEFAULT_FILE_SIZE_LIMIT;
 import static com.aliyun.oss.internal.OSSConstants.DEFAULT_CHARSET_NAME;
 import static com.aliyun.oss.internal.ResponseParsers.completeMultipartUploadResponseParser;
-import static com.aliyun.oss.internal.ResponseParsers.completeMultipartUploadCallbackResponseParser;
+import static com.aliyun.oss.internal.ResponseParsers.completeMultipartUploadProcessResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.initiateMultipartUploadResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.listMultipartUploadsResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.listPartsResponseParser;
@@ -181,10 +181,10 @@ public class OSSMultipartOperation extends OSSOperation {
         reponseHandlers.add(new OSSCallbackErrorResponseHandler());
         
         CompleteMultipartUploadResult result = null;
-        if (completeMultipartUploadRequest.getCallback() == null) {
+        if (!isNeedReturnResponse(completeMultipartUploadRequest)) {
             result = doOperation(request, completeMultipartUploadResponseParser, bucketName, key, true);
         } else {
-            result =  doOperation(request, completeMultipartUploadCallbackResponseParser, bucketName, key, true, null, reponseHandlers);
+            result =  doOperation(request, completeMultipartUploadProcessResponseParser, bucketName, key, true, null, reponseHandlers);
         }
         
         result.setClientCRC(calcObjectCRCFromParts(completeMultipartUploadRequest.getPartETags()));
@@ -571,4 +571,11 @@ public class OSSMultipartOperation extends OSSOperation {
         return new Long(crc);
     }
     
+    private static boolean isNeedReturnResponse(CompleteMultipartUploadRequest completeMultipartUploadRequest) {
+    	if (completeMultipartUploadRequest.getCallback() != null || 
+    			completeMultipartUploadRequest.getProcess() != null) {
+    		return true;
+    	}
+    	return false;
+    }
 }

--- a/src/main/java/com/aliyun/oss/internal/OSSObjectOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSObjectOperation.java
@@ -55,7 +55,7 @@ import static com.aliyun.oss.internal.ResponseParsers.deleteObjectsResponseParse
 import static com.aliyun.oss.internal.ResponseParsers.getObjectAclResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.getObjectMetadataResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.putObjectReponseParser;
-import static com.aliyun.oss.internal.ResponseParsers.putObjectCallbackReponseParser;
+import static com.aliyun.oss.internal.ResponseParsers.putObjectProcessReponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.getSimplifiedObjectMetaResponseParser;
 import static com.aliyun.oss.internal.ResponseParsers.getSymbolicLinkResponseParser;
 
@@ -141,10 +141,10 @@ public class OSSObjectOperation extends OSSOperation {
         
         PutObjectResult result = null;
         
-        if (putObjectRequest.getCallback() == null) {
+        if (!isNeedReturnResponse(putObjectRequest)) {
             result = writeObjectInternal(WriteMode.OVERWRITE, putObjectRequest, putObjectReponseParser);
         } else {
-            result = writeObjectInternal(WriteMode.OVERWRITE, putObjectRequest, putObjectCallbackReponseParser);
+            result = writeObjectInternal(WriteMode.OVERWRITE, putObjectRequest, putObjectProcessReponseParser);
         }
         
         if (isCrcCheckEnabled()) {
@@ -180,7 +180,7 @@ public class OSSObjectOperation extends OSSOperation {
         if (requestHeaders.get(OSSHeaders.OSS_HEADER_CALLBACK) == null) {
             result = doOperation(request, putObjectReponseParser, null, null, true);    
         } else {
-            result = doOperation(request, putObjectCallbackReponseParser, null, null, true);    
+            result = doOperation(request, putObjectProcessReponseParser, null, null, true);    
         }
         
         if (isCrcCheckEnabled()) {
@@ -899,4 +899,12 @@ public class OSSObjectOperation extends OSSOperation {
             params.put(RequestParameters.POSITION, String.valueOf(appendObjectRequest.getPosition()));            
         }
     }
+    
+    private static boolean isNeedReturnResponse(PutObjectRequest putObjectRequest) {
+    	if (putObjectRequest.getCallback() != null || putObjectRequest.getProcess() != null) {
+    		return true;
+    	}
+    	return false;
+    }
+    
 }

--- a/src/main/java/com/aliyun/oss/internal/OSSOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSOperation.java
@@ -152,8 +152,8 @@ public abstract class OSSOperation {
             return parser.parse(response);
         } catch (ResponseParseException rpe) {
             OSSException oe = ExceptionFactory.createInvalidResponseException(
-                    response.getRequestId(), response.getErrorResponseAsString(), rpe);
-            logException("Unable to parse response error: ", oe);
+                    response.getRequestId(), rpe.getMessage(), rpe);
+            logException("Unable to parse response error: ", rpe);
             throw oe;
         }
     }

--- a/src/main/java/com/aliyun/oss/internal/OSSUtils.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSUtils.java
@@ -82,7 +82,7 @@ public class OSSUtils {
      */
     public static boolean validateObjectKey(String key) {
         
-        if (key == null) {
+        if (key == null || key.length() == 0) {
             return false;
         }
         
@@ -222,22 +222,26 @@ public class OSSUtils {
         Map<String, Object> rawMetadata = metadata.getRawMetadata();
         if (rawMetadata != null) {
             for (Entry<String, Object> entry : rawMetadata.entrySet()) {
-                String key = entry.getKey();
-                String value = entry.getValue().toString();
-                if (key != null) key = key.trim();
-                if (value != null) value = value.trim();
-                headers.put(key, value);
+            	if (entry.getKey() != null && entry.getValue() != null) {
+					String key = entry.getKey();
+					String value = entry.getValue().toString();
+					if (key != null) key = key.trim();
+					if (value != null) value = value.trim();
+					headers.put(key, value);
+            	}
             }
         }
 
         Map<String, String> userMetadata = metadata.getUserMetadata();
         if (userMetadata != null) {
             for (Entry<String, String> entry : userMetadata.entrySet()) {
-                String key = entry.getKey();
-                String value = entry.getValue();
-                if (key != null) key = key.trim();
-                if (value != null) value = value.trim();
-                headers.put(OSSHeaders.OSS_USER_METADATA_PREFIX + key, value);
+            	if (entry.getKey() != null && entry.getValue() != null) {
+	                String key = entry.getKey();
+	                String value = entry.getValue();
+	                if (key != null) key = key.trim();
+	                if (value != null) value = value.trim();
+	                headers.put(OSSHeaders.OSS_USER_METADATA_PREFIX + key, value);
+            	}
             }
         }
     }

--- a/src/main/java/com/aliyun/oss/internal/RequestParameters.java
+++ b/src/main/java/com/aliyun/oss/internal/RequestParameters.java
@@ -50,6 +50,7 @@ public final class RequestParameters {
     public static final String SUBRESOURCE_PROCESS_CONF = "processConfiguration";
     public static final String SUBRESOURCE_PROCESS = "x-oss-process";
     public static final String SUBRESOURCE_SYMLINK = "symlink"; 
+    public static final String SUBRESOURCE_STAT = "stat";
     
     public static final String PREFIX = "prefix";
     public static final String DELIMITER = "delimiter";

--- a/src/main/java/com/aliyun/oss/internal/SignUtils.java
+++ b/src/main/java/com/aliyun/oss/internal/SignUtils.java
@@ -52,6 +52,7 @@ import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_END_TIME;
 import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_PROCESS_CONF;
 import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_PROCESS;
 import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_SYMLINK;
+import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_STAT;
 import static com.aliyun.oss.internal.RequestParameters.UPLOAD_ID;
 import static com.aliyun.oss.internal.RequestParameters.SUBRESOURCE_QOS;
 import static com.aliyun.oss.model.ResponseHeaderOverrides.RESPONSE_HEADER_CACHE_CONTROL;
@@ -88,7 +89,7 @@ public class SignUtils {
             SUBRESOURCE_BUCKET_INFO, SUBRESOURCE_COMP, SUBRESOURCE_QOS,
             SUBRESOURCE_LIVE, SUBRESOURCE_STATUS, SUBRESOURCE_VOD, 
             SUBRESOURCE_START_TIME, SUBRESOURCE_END_TIME, SUBRESOURCE_PROCESS,
-            SUBRESOURCE_PROCESS_CONF, SUBRESOURCE_SYMLINK,  
+            SUBRESOURCE_PROCESS_CONF, SUBRESOURCE_SYMLINK, SUBRESOURCE_STAT,  
     });
     
     public static String buildCanonicalString(String method, String resourcePath,

--- a/src/main/java/com/aliyun/oss/model/AccessControlList.java
+++ b/src/main/java/com/aliyun/oss/model/AccessControlList.java
@@ -34,7 +34,8 @@ public class AccessControlList implements Serializable {
     private static final long serialVersionUID = 211267925081748283L;
 
     private HashSet<Grant> grants = new HashSet<Grant>();
-    private Owner owner;
+    private CannedAccessControlList cannedACL;
+	private Owner owner;
 
     /**
      * 返回所有者{@link Owner}。
@@ -92,14 +93,31 @@ public class AccessControlList implements Serializable {
      * 返回该{@link AccessControlList}中包含的所有授权信息{@link Grant}。
      * @return 该{@link AccessControlList}中包含的所有授权信息。
      */
+    @Deprecated
     public Set<Grant> getGrants() {
         return this.grants;
     }
+    
+    /**
+     * 返回权限
+     * @return cannedACL
+     */
+    public CannedAccessControlList getCannedACL() {
+		return cannedACL;
+	}
+
+    /**
+     * 设置权限
+     * @param cannedACL
+     */
+	public void setCannedACL(CannedAccessControlList cannedACL) {
+		this.cannedACL = cannedACL;
+	}
 
     /**
      * 返回该对象的字符串表示。
      */
     public String toString() {
-        return "AccessControlList [owner=" + owner + ", grants=" + getGrants() + "]";
+        return "AccessControlList [owner=" + owner + ", ACL=" + getCannedACL() + "]";
     }
 }

--- a/src/main/java/com/aliyun/oss/model/BucketInfo.java
+++ b/src/main/java/com/aliyun/oss/model/BucketInfo.java
@@ -34,6 +34,7 @@ public class BucketInfo {
         this.bucket = bucket;
     }
 
+    @Deprecated
     public Set<Grant> getGrants() {
         return this.grants;
     }
@@ -45,8 +46,16 @@ public class BucketInfo {
         
         grants.add(new Grant(grantee, permission));
     }
+    
+	public CannedAccessControlList getCannedACL() {
+		return cannedACL;
+	}
+
+	public void setCannedACL(CannedAccessControlList cannedACL) {
+		this.cannedACL = cannedACL;
+	}
 
     private Bucket bucket;
     private Set<Grant> grants = new HashSet<Grant>();
-
+    private CannedAccessControlList cannedACL;
 }

--- a/src/main/java/com/aliyun/oss/model/BucketStat.java
+++ b/src/main/java/com/aliyun/oss/model/BucketStat.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.aliyun.oss.model;
+
+/**
+ * Bucket Stat
+ */
+public class BucketStat {
+
+	public BucketStat(Long storageSize, Long objectCount, Long multipartUploadCount) {
+		this.storageSize = storageSize;
+		this.objectCount = objectCount;
+		this.multipartUploadCount = multipartUploadCount;
+	}
+
+	/**
+	 * 返回Bucket存储量，单位byte
+	 * @return Bucket存储量
+	 */
+	public Long getStorageSize() {
+		return storageSize;
+	}
+
+	/**
+	 * 返回Bucket中Object的数量
+	 * @return Object的数量
+	 */
+	public Long getObjectCount() {
+		return objectCount;
+	}
+
+	/**
+	 * 返回Bucket下未完成的分片上传任务数
+	 * @return 未完成的分片上传任务数
+	 */
+	public Long getMultipartUploadCount() {
+		return multipartUploadCount;
+	}
+
+	private Long storageSize; // bytes
+	private Long objectCount;
+	private Long multipartUploadCount;
+}

--- a/src/main/java/com/aliyun/oss/model/CnameConfiguration.java
+++ b/src/main/java/com/aliyun/oss/model/CnameConfiguration.java
@@ -56,6 +56,14 @@ public class CnameConfiguration {
         this.lastMofiedTime = lastMofiedTime;
     }
     
+	public Boolean getPurgeCdnCache() {
+		return purgeCdnCache;
+	}
+
+	public void setPurgeCdnCache(Boolean purgeCdnCache) {
+		this.purgeCdnCache = purgeCdnCache;
+	}
+    
     @Override
     public String toString() {
         return "CnameConfiguration [domain=" + domain + 
@@ -66,5 +74,5 @@ public class CnameConfiguration {
     private String domain;
     private CnameStatus status;
     private Date lastMofiedTime;
-
+    private Boolean purgeCdnCache;
 }

--- a/src/main/java/com/aliyun/oss/model/CompleteMultipartUploadRequest.java
+++ b/src/main/java/com/aliyun/oss/model/CompleteMultipartUploadRequest.java
@@ -38,6 +38,9 @@ public class CompleteMultipartUploadRequest extends GenericRequest {
     
     /** callback */
     private Callback callback;
+    
+    /** process **/
+    private String process;
 
     /**
      * 构造函数。
@@ -116,4 +119,11 @@ public class CompleteMultipartUploadRequest extends GenericRequest {
         this.callback = callback;
     }
     
+    public String getProcess() {
+		return process;
+	}
+
+	public void setProcess(String process) {
+		this.process = process;
+	}
 }

--- a/src/main/java/com/aliyun/oss/model/CompleteMultipartUploadResult.java
+++ b/src/main/java/com/aliyun/oss/model/CompleteMultipartUploadResult.java
@@ -109,10 +109,11 @@ public class CompleteMultipartUploadResult extends GenericResult implements Call
     }
     
     /**
-     * 获取回调返回的消息体，需要close。
+     * 获取回调返回的消息体，需要close，使用this.getResponse().getContent()代替。。
      * @return 回调返回的消息体
      */
     @Override
+    @Deprecated
     public InputStream getCallbackResponseBody() {
         return callbackResponseBody;
     }

--- a/src/main/java/com/aliyun/oss/model/DownloadFileRequest.java
+++ b/src/main/java/com/aliyun/oss/model/DownloadFileRequest.java
@@ -73,6 +73,10 @@ public class DownloadFileRequest extends GenericRequest {
     public String getDownloadFile() {
         return downloadFile;
     }
+    
+    public String getTempDownloadFile() {
+        return downloadFile + ".tmp";
+    }
 
     public void setDownloadFile(String downloadFile) {
         this.downloadFile = downloadFile;

--- a/src/main/java/com/aliyun/oss/model/GenericResult.java
+++ b/src/main/java/com/aliyun/oss/model/GenericResult.java
@@ -19,6 +19,8 @@
 
 package com.aliyun.oss.model;
 
+import com.aliyun.oss.common.comm.ResponseMessage;
+
 /**
  * A generic result that contains some basic response options, such as requestId.
  */
@@ -48,7 +50,16 @@ public abstract class GenericResult {
         this.serverCRC = serverCRC;
     }
     
+	public ResponseMessage getResponse() {
+		return response;
+	}
+
+	public void setResponse(ResponseMessage response) {
+		this.response = response;
+	}
+	
     private String requestId;
     private Long clientCRC;
     private Long serverCRC;
+    ResponseMessage response;
 }

--- a/src/main/java/com/aliyun/oss/model/OSSObject.java
+++ b/src/main/java/com/aliyun/oss/model/OSSObject.java
@@ -19,6 +19,8 @@
 
 package com.aliyun.oss.model;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -38,7 +40,7 @@ import java.io.InputStream;
  * </p>
  *
  */
-public class OSSObject extends GenericResult {
+public class OSSObject extends GenericResult implements Closeable {
 
     // Object key (name)
     private String key;
@@ -119,7 +121,22 @@ public class OSSObject extends GenericResult {
     public void setKey(String key) {
         this.key = key;
     }
-
+    
+    @Override
+    public void close() throws IOException {
+        if (objectContent != null) {
+            objectContent.close();
+        }
+    }
+    
+    /**
+     * 强制关闭，放弃读取剩余数据。
+     * @throws IOException
+     */
+    public void forcedClose() throws IOException {
+    	this.response.abort();
+    }
+    
     @Override
     public String toString() {
         return "OSSObject [key=" + getKey()

--- a/src/main/java/com/aliyun/oss/model/PutObjectRequest.java
+++ b/src/main/java/com/aliyun/oss/model/PutObjectRequest.java
@@ -30,6 +30,7 @@ public class PutObjectRequest extends GenericRequest {
     private ObjectMetadata metadata;
     
     private Callback callback;
+    private String process;
 
     public PutObjectRequest(String bucketName, String key, File file) {
         this(bucketName, key, file, null);
@@ -83,4 +84,11 @@ public class PutObjectRequest extends GenericRequest {
         this.callback = callback;
     }
     
+    public String getProcess() {
+		return process;
+	}
+
+	public void setProcess(String process) {
+		this.process = process;
+	}
 }

--- a/src/main/java/com/aliyun/oss/model/PutObjectResult.java
+++ b/src/main/java/com/aliyun/oss/model/PutObjectResult.java
@@ -50,10 +50,11 @@ public class PutObjectResult extends GenericResult implements CallbackResult {
     }
     
     /**
-     * 获取回调返回的消息体，需要close。
+     * 获取回调返回的消息体，需要close，使用this.getResponse().getContent()代替。
      * @return 回调返回的消息体
      */
     @Override
+    @Deprecated
     public InputStream getCallbackResponseBody() {
         return callbackResponseBody;
     }

--- a/src/main/resources/mime.types
+++ b/src/main/resources/mime.types
@@ -147,6 +147,7 @@ ez    application/andrew-inset
 gram    application/srgs
 grxml    application/srgs+xml
 gz    application/x-gzip
+tgz   application/x-gzip
 htm    text/html
 html    text/html
 ico    image/x-icon

--- a/src/test/java/com/aliyun/oss/OSSResponseParserTest.java
+++ b/src/test/java/com/aliyun/oss/OSSResponseParserTest.java
@@ -106,7 +106,8 @@ public class OSSResponseParserTest {
 
     }
 
-    @Test
+    @SuppressWarnings("deprecation")
+	@Test
     public void testParseGetBucketAcl() throws Exception {
 
         String filename = "getBucketAcl.xml";

--- a/src/test/java/com/aliyun/oss/integrationtests/BucketAclTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/BucketAclTest.java
@@ -35,6 +35,7 @@ import com.aliyun.oss.model.Grant;
 import com.aliyun.oss.model.GroupGrantee;
 import com.aliyun.oss.model.Permission;
 
+@SuppressWarnings("deprecation")
 public class BucketAclTest extends TestBase {
 
     private static final CannedAccessControlList[] acls = {
@@ -67,6 +68,10 @@ public class BucketAclTest extends TestBase {
                         Assert.assertEquals(GroupGrantee.AllUsers, grant.getGrantee());
                         Assert.assertEquals(Permission.FullControl, grant.getPermission());
                     }
+                }
+                
+                if (acl != null ) {
+                    Assert.assertEquals(returnedAcl.getCannedACL(), acl);
                 }
             }
             

--- a/src/test/java/com/aliyun/oss/integrationtests/BucketInfoTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/BucketInfoTest.java
@@ -33,7 +33,8 @@ import com.aliyun.oss.model.Permission;
 
 public class BucketInfoTest extends TestBase {
 
-    @Test
+    @SuppressWarnings("deprecation")
+	@Test
     public void testGetBucketInfo() {
         try {
             ossClient.setBucketAcl(bucketName, CannedAccessControlList.PublicRead);
@@ -42,7 +43,10 @@ public class BucketInfoTest extends TestBase {
             Assert.assertEquals(info.getBucket().getName(), bucketName);
             Assert.assertEquals(info.getBucket().getLocation(), TestConfig.OSS_TEST_REGION);
             Assert.assertNotNull(info.getBucket().getCreationDate());
+            Assert.assertTrue(info.getBucket().getExtranetEndpoint().length() > 0);
+            Assert.assertTrue(info.getBucket().getIntranetEndpoint().length() > 0);
             Assert.assertTrue(info.getBucket().getOwner().getId().length() > 0);
+            Assert.assertEquals(CannedAccessControlList.PublicRead, info.getCannedACL());
             Assert.assertEquals(info.getBucket().getOwner().getDisplayName(), info.getBucket().getOwner().getId());
             Assert.assertEquals(info.getGrants().size(), 1);
             for (Grant grant : info.getGrants()) {

--- a/src/test/java/com/aliyun/oss/integrationtests/BucketStatTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/BucketStatTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.aliyun.oss.integrationtests;
+
+import junit.framework.Assert;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import com.aliyun.oss.OSSErrorCode;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.model.AbortMultipartUploadRequest;
+import com.aliyun.oss.model.BucketStat;
+import com.aliyun.oss.model.InitiateMultipartUploadRequest;
+import com.aliyun.oss.model.InitiateMultipartUploadResult;
+import com.aliyun.oss.model.UploadFileRequest;
+import com.aliyun.oss.model.UploadFileResult;
+
+public class BucketStatTest extends TestBase {
+
+    @Test
+    public void testGetBucketStat() {
+    	String key = "obj-upload-file-stat.txt";
+    	String uploadId = null;
+    	
+        try {
+        	
+            File file = createSampleFile(key, 1024 * 500);
+            
+            // upload a file
+            UploadFileRequest uploadFileRequest = new UploadFileRequest(bucketName, key);
+            uploadFileRequest.setUploadFile(file.getAbsolutePath());
+            uploadFileRequest.setTaskNum(10);
+            
+            UploadFileResult uploadRes = ossClient.uploadFile(uploadFileRequest);
+            Assert.assertEquals(uploadRes.getMultipartUploadResult().getBucketName(), bucketName);
+            Assert.assertEquals(uploadRes.getMultipartUploadResult().getKey(), key);
+            
+            // init upload
+            InitiateMultipartUploadRequest initiateMultipartUploadRequest = 
+                    new InitiateMultipartUploadRequest(bucketName, key);
+            InitiateMultipartUploadResult initiateMultipartUploadResult = 
+                    ossClient.initiateMultipartUpload(initiateMultipartUploadRequest);
+            uploadId = initiateMultipartUploadResult.getUploadId();
+            
+            BucketStat stat = ossClient.getBucketStat(bucketName);
+            System.out.println(stat.getStorageSize() + "," + stat.getObjectCount() + "," + stat.getMultipartUploadCount());
+            Assert.assertTrue(stat.getStorageSize() >= 1024 * 300);
+            Assert.assertTrue(stat.getObjectCount() >= 1);
+            Assert.assertTrue(stat.getMultipartUploadCount() >= 1);
+        } catch (Exception e) {
+        	e.printStackTrace();
+            Assert.fail(e.getMessage());
+        } catch (Throwable e) {
+        	e.printStackTrace();
+            Assert.fail(e.getMessage());
+        } finally {
+        	if (uploadId != null) {
+                AbortMultipartUploadRequest AbortMultipartUploadRequest = 
+                		new AbortMultipartUploadRequest(bucketName, key, uploadId);
+                ossClient.abortMultipartUpload(AbortMultipartUploadRequest);
+        	}
+        }
+    }
+    
+    @Test
+    public void testUnormalGetBucketStat() {
+        final String bucketName = "unormal-get-bucket-stat";
+        
+        // bucket non-existent 
+        try {            
+            ossClient.getBucketStat(bucketName);
+            Assert.fail("Get bucket stat should not be successful");
+        } catch (OSSException e) {
+            Assert.assertEquals(OSSErrorCode.NO_SUCH_BUCKET, e.getErrorCode());
+        }
+
+    }
+    
+}

--- a/src/test/java/com/aliyun/oss/integrationtests/CallbackTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/CallbackTest.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 import com.aliyun.oss.HttpMethod;
 import com.aliyun.oss.OSSErrorCode;
 import com.aliyun.oss.OSSException;
-import com.aliyun.oss.internal.OSSHeaders;
 import com.aliyun.oss.internal.OSSUtils;
 import com.aliyun.oss.model.Callback;
 import com.aliyun.oss.model.Callback.CalbackBodyType;
@@ -56,7 +55,7 @@ import com.aliyun.oss.model.UploadPartResult;
  * Test callBack of PutObject and MultipartUpload
  * 
  */
-@SuppressWarnings("unused")
+@SuppressWarnings("deprecation")
 public class CallbackTest extends TestBase {
     
     private static final String callbackUrl = "callback.oss-demo.com:23450";
@@ -89,6 +88,7 @@ public class CallbackTest extends TestBase {
             OSSObject obj = ossClient.getObject(bucketName, key);
             Assert.assertEquals(key, obj.getKey());
             Assert.assertEquals(instreamLength, obj.getObjectMetadata().getContentLength());
+            obj.forcedClose();
 
         } catch (Exception ex) {
             Assert.fail(ex.getMessage());
@@ -122,6 +122,7 @@ public class CallbackTest extends TestBase {
             OSSObject obj = ossClient.getObject(bucketName, key);
             Assert.assertEquals(key, obj.getKey());
             Assert.assertEquals(instreamLength, obj.getObjectMetadata().getContentLength());
+            obj.close();
 
         } catch (Exception ex) {
             Assert.fail(ex.getMessage());
@@ -183,8 +184,8 @@ public class CallbackTest extends TestBase {
             
             PutObjectResult putObjectResult = ossClient.putObject(putObjectRequest);
             byte[] buffer = new byte[bufferLength];
-            int nRead = putObjectResult.getCallbackResponseBody().read(buffer);
-            putObjectResult.getCallbackResponseBody().close();
+            int nRead = putObjectResult.getResponse().getContent().read(buffer);
+            putObjectResult.getResponse().getContent().close();
             Assert.assertEquals(callbackResponse, new String(buffer, 0, nRead));
             
             OSSObject obj = ossClient.getObject(bucketName, key);
@@ -480,13 +481,14 @@ public class CallbackTest extends TestBase {
                     ossClient.completeMultipartUpload(completeMultipartUploadRequest);
                         
             byte[] buffer = new byte[bufferLength];
-            int nRead = completeMultipartUploadResult.getCallbackResponseBody().read(buffer);
-            completeMultipartUploadResult.getCallbackResponseBody().close();
+            int nRead = completeMultipartUploadResult.getResponse().getContent().read(buffer);
+            completeMultipartUploadResult.getResponse().getContent().close();
             Assert.assertEquals(callbackResponse, new String(buffer, 0, nRead));
                     
             OSSObject obj = ossClient.getObject(bucketName, key);
             Assert.assertEquals(key, obj.getKey());
             Assert.assertEquals(instreamLength, obj.getObjectMetadata().getContentLength());
+            obj.forcedClose();
 
         } catch (Exception ex) {
             Assert.fail(ex.getMessage());
@@ -535,6 +537,7 @@ public class CallbackTest extends TestBase {
             OSSObject obj = ossClient.getObject(bucketName, key);
             Assert.assertEquals(key, obj.getKey());
             Assert.assertEquals(instreamLength, obj.getObjectMetadata().getContentLength());
+            obj.close();
 
         } catch (Exception ex) {
             Assert.fail(ex.getMessage());

--- a/src/test/java/com/aliyun/oss/integrationtests/CreateBucketTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/CreateBucketTest.java
@@ -48,6 +48,7 @@ import com.aliyun.oss.model.GroupGrantee;
 import com.aliyun.oss.model.Permission;
 import com.aliyun.oss.model.StorageClass;
 
+@SuppressWarnings("deprecation")
 public class CreateBucketTest extends TestBase {
     
     private static final int MAX_BUCKETS_ALLOWED = 10;
@@ -224,6 +225,7 @@ public class CreateBucketTest extends TestBase {
             AccessControlList returnedAcl = ossClient.getBucketAcl(bucketName);
             Set<Grant> grants = returnedAcl.getGrants();
             Assert.assertEquals(0, grants.size());
+            Assert.assertEquals(returnedAcl.getCannedACL(), CannedAccessControlList.Private);
             
             // Try to create existing bucket without setting acl
             ossClient.createBucket(bucketName);
@@ -242,6 +244,7 @@ public class CreateBucketTest extends TestBase {
             Grant grant = (Grant) grants.toArray()[0];
             Assert.assertEquals(GroupGrantee.AllUsers, grant.getGrantee());
             Assert.assertEquals(Permission.Read, grant.getPermission());
+            Assert.assertEquals(returnedAcl.getCannedACL(), CannedAccessControlList.PublicRead);
             
             // Try to create existing bucket without setting acl
             ossClient.createBucket(bucketName);
@@ -263,6 +266,7 @@ public class CreateBucketTest extends TestBase {
             grant = (Grant) grants.toArray()[0];
             Assert.assertEquals(GroupGrantee.AllUsers, grant.getGrantee());
             Assert.assertEquals(Permission.FullControl, grant.getPermission());
+            Assert.assertEquals(returnedAcl.getCannedACL(), CannedAccessControlList.PublicReadWrite);
             
             // Try to create existing bucket without setting acl
             ossClient.createBucket(bucketName);

--- a/src/test/java/com/aliyun/oss/integrationtests/SecurityTokenTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/SecurityTokenTest.java
@@ -70,7 +70,8 @@ public class SecurityTokenTest {
     private static final String DUMMY_SUFFIX = "xyz";
     private static final String STS_USER = "sts";
 
-    @Test
+    @SuppressWarnings("deprecation")
+	@Test
     public void testBucketOperationsWithToken() {
         List<String> actions = new ArrayList<String>();
         actions.add("oss:ListBuckets");


### PR DESCRIPTION
### 变更内容
- 添加：支持get bucket stat
- 添加：CName支持IsPurgeCdnCache
- 添加：强制关闭OSSObject的功能
- 修复：断点续传下载不成功不修改本地同名文件
- 修复：BucketInfo添加解析ExtranetEndpoint/IntranetEndpoint
- 修复：修复key为""时抛IndexOutOfBoundException的异常
- 修复：initiateMultipartUpload特定情况下抛NullPointerException的异常
- 优化：AccessControlList中添加权限直接描述
- 优化：统一UDF/上传回调后返回的Response
- 优化：InvalidResponse异常的描述信息中添加上下文信息
