### PR TITLE
Fix #123: Remove redundant dependency 'jersey'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
             <version>1.1</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-json</artifactId>
-            <version>1.9</version>
+            <groupId>org.codehaus.jettison</groupId>
+            <artifactId>jettison</artifactId>
+            <version>1.1</version>
         </dependency>
         <dependency>
             <groupId>com.aliyun</groupId>


### PR DESCRIPTION
Currently we use `jersey-json` as a dependency, but actually in java code only one dependency of `jersey-json` - `jettison` is being used.

As #123 said, `com.sun.jersey:jersey:1.x` is an obsolete library and it caused several collision with other libraries (In my case, it breaks RestAPI of Spark). The best solution is to just remove it.