### PR TITLE
Support object versions lifecycle.

### DIFF
--- a/src/main/java/com/aliyun/oss/OSSClient.java
+++ b/src/main/java/com/aliyun/oss/OSSClient.java
@@ -1242,32 +1242,32 @@ public class OSSClient implements OSS {
 
     @Override
     public void setBucketPolicy(String bucketName,  String policyText) throws OSSException, ClientException {
-    	this.bucketOperation.setBucketPolicy(new SetBucketPolicyRequest(bucketName, policyText));
+        this.setBucketPolicy(new SetBucketPolicyRequest(bucketName, policyText));
     }
 
     @Override
     public void setBucketPolicy(SetBucketPolicyRequest setBucketPolicyRequest) throws OSSException, ClientException {
-    	this.bucketOperation.setBucketPolicy(setBucketPolicyRequest);
+        this.bucketOperation.setBucketPolicy(setBucketPolicyRequest);
     }
 
     @Override
     public GetBucketPolicyResult getBucketPolicy(GenericRequest genericRequest) throws OSSException, ClientException {
-    	return bucketOperation.getBucketPolicy(genericRequest);
+        return this.bucketOperation.getBucketPolicy(genericRequest);
     }
 
     @Override
     public GetBucketPolicyResult getBucketPolicy(String bucketName) throws OSSException, ClientException {
-    	return bucketOperation.getBucketPolicy(new GenericRequest(bucketName));
+        return this.getBucketPolicy(new GenericRequest(bucketName));
     }
 
     @Override
     public void deleteBucketPolicy(GenericRequest genericRequest) throws OSSException, ClientException {
-    	bucketOperation.deleteBucketPolicy(genericRequest);
+        this.bucketOperation.deleteBucketPolicy(genericRequest);
     }
 
     @Override
     public void deleteBucketPolicy(String bucketName) throws OSSException, ClientException {
-    	bucketOperation.deleteBucketPolicy(new GenericRequest(bucketName));
+        this.deleteBucketPolicy(new GenericRequest(bucketName));
     }
 
     @Override
@@ -1420,7 +1420,7 @@ public class OSSClient implements OSS {
 
     @Override
     public void setBucketRequestPayment(String bucketName, Payer payer) throws OSSException, ClientException {
-        this.bucketOperation.setBucketRequestPayment(new SetBucketRequestPaymentRequest(bucketName, payer));
+        this.setBucketRequestPayment(new SetBucketRequestPaymentRequest(bucketName, payer));
     }
 
     @Override
@@ -1430,7 +1430,7 @@ public class OSSClient implements OSS {
 
     @Override
     public GetBucketRequestPaymentResult getBucketRequestPayment(String bucketName) throws OSSException, ClientException {
-        return this.bucketOperation.getBucketRequestPayment(new GenericRequest(bucketName));
+        return this.getBucketRequestPayment(new GenericRequest(bucketName));
     }
 
     @Override
@@ -1440,7 +1440,7 @@ public class OSSClient implements OSS {
 
     @Override
     public void setBucketQosInfo(String bucketName, BucketQosInfo bucketQosInfo) throws OSSException, ClientException {
-        this.bucketOperation.setBucketQosInfo(new SetBucketQosInfoRequest(bucketName, bucketQosInfo));
+        this.setBucketQosInfo(new SetBucketQosInfoRequest(bucketName, bucketQosInfo));
     }
 
     @Override
@@ -1450,7 +1450,7 @@ public class OSSClient implements OSS {
 
     @Override
     public BucketQosInfo getBucketQosInfo(String bucketName) throws OSSException, ClientException {
-        return this.bucketOperation.getBucketQosInfo(new GenericRequest(bucketName));
+        return this.getBucketQosInfo(new GenericRequest(bucketName));
     }
 
     @Override
@@ -1460,7 +1460,7 @@ public class OSSClient implements OSS {
 
     @Override
     public void deleteBucketQosInfo(String bucketName) throws OSSException, ClientException {
-        this.bucketOperation.deleteBucketQosInfo(new GenericRequest(bucketName));
+        this.deleteBucketQosInfo(new GenericRequest(bucketName));
     }
  
     @Override

--- a/src/main/java/com/aliyun/oss/common/parser/RequestMarshallers.java
+++ b/src/main/java/com/aliyun/oss/common/parser/RequestMarshallers.java
@@ -40,6 +40,8 @@ import com.aliyun.oss.model.DeleteVersionsRequest.KeyVersion;
 import com.aliyun.oss.model.LifecycleRule.AbortMultipartUpload;
 import com.aliyun.oss.model.LifecycleRule.RuleStatus;
 import com.aliyun.oss.model.LifecycleRule.StorageTransition;
+import com.aliyun.oss.model.LifecycleRule.NoncurrentVersionStorageTransition;
+import com.aliyun.oss.model.LifecycleRule.NoncurrentVersionExpiration;
 import com.aliyun.oss.model.SetBucketCORSRequest.CORSRule;
 
 /**
@@ -401,6 +403,9 @@ public final class RequestMarshallers {
                     String formatDate = DateUtil.formatIso8601Date(rule.getCreatedBeforeDate());
                     xmlBody.append(
                             "<Expiration><CreatedBeforeDate>" + formatDate + "</CreatedBeforeDate></Expiration>");
+                } else if (rule.getExpiredDeleteMarker() != null) {
+                    xmlBody.append("<Expiration><ExpiredObjectDeleteMarker>" + rule.getExpiredDeleteMarker() +
+                            "</ExpiredObjectDeleteMarker></Expiration>");
                 }
 
                 if (rule.hasAbortMultipartUpload()) {
@@ -426,6 +431,23 @@ public final class RequestMarshallers {
                         }
                         xmlBody.append("<StorageClass>" + storageTransition.getStorageClass() + "</StorageClass>");
                         xmlBody.append("</Transition>");
+                    }
+                }
+
+                if (rule.hasNoncurrentVersionExpiration()) {
+                    NoncurrentVersionExpiration expiration = rule.getNoncurrentVersionExpiration();
+                    if (expiration.hasNoncurrentDays()) {
+                        xmlBody.append("<NoncurrentVersionExpiration><NoncurrentDays>" + expiration.getNoncurrentDays() +
+                                "</NoncurrentDays></NoncurrentVersionExpiration>");
+                    }
+                }
+
+                if (rule.hasNoncurrentVersionStorageTransitions()) {
+                    for (NoncurrentVersionStorageTransition transition : rule.getNoncurrentVersionStorageTransitions()) {
+                        xmlBody.append("<NoncurrentVersionTransition>");
+                        xmlBody.append("<NoncurrentDays>" + transition.getNoncurrentDays() + "</NoncurrentDays>");
+                        xmlBody.append("<StorageClass>" + transition.getStorageClass() + "</StorageClass>");
+                        xmlBody.append("</NoncurrentVersionTransition>");
                     }
                 }
 

--- a/src/main/java/com/aliyun/oss/internal/OSSUtils.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSUtils.java
@@ -52,7 +52,7 @@ public class OSSUtils {
     public static final ResourceManager OSS_RESOURCE_MANAGER = ResourceManager.getInstance(RESOURCE_NAME_OSS);
     public static final ResourceManager COMMON_RESOURCE_MANAGER = ResourceManager.getInstance(RESOURCE_NAME_COMMON);
 
-    private static final String BUCKET_NAMING_REGEX = "^[a-z0-9][a-z0-9_\\-]{1,61}[a-z0-9]$";
+    private static final String BUCKET_NAMING_REGEX = "^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$";
 
     /**
      * Validate bucket name.

--- a/src/main/java/com/aliyun/oss/model/DownloadFileRequest.java
+++ b/src/main/java/com/aliyun/oss/model/DownloadFileRequest.java
@@ -19,6 +19,8 @@
 
 package com.aliyun.oss.model;
 
+import com.aliyun.oss.common.utils.BinaryUtil;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -75,7 +77,11 @@ public class DownloadFileRequest extends GenericRequest {
     }
 
     public String getTempDownloadFile() {
-        return downloadFile + ".tmp";
+        if (getVersionId() != null) {
+            return downloadFile + "." + BinaryUtil.encodeMD5(getVersionId().getBytes()) + ".tmp";
+        } else {
+            return downloadFile + ".tmp";
+        }
     }
 
     public void setDownloadFile(String downloadFile) {

--- a/src/main/java/com/aliyun/oss/model/LifecycleRule.java
+++ b/src/main/java/com/aliyun/oss/model/LifecycleRule.java
@@ -151,18 +151,93 @@ public class LifecycleRule {
         }
     }
 
+    public static class NoncurrentVersionStorageTransition {
+        private Integer noncurrentDays;
+        private StorageClass storageClass;
+
+        public NoncurrentVersionStorageTransition() {
+        }
+
+        public NoncurrentVersionStorageTransition(Integer noncurrentDays, StorageClass storageClass) {
+            this.noncurrentDays = noncurrentDays;
+            this.storageClass = storageClass;
+        }
+
+        public Integer getNoncurrentDays() {
+            return noncurrentDays;
+        }
+
+        public void setNoncurrentDays(Integer noncurrentDays) {
+            this.noncurrentDays = noncurrentDays;
+        }
+
+        public NoncurrentVersionStorageTransition withNoncurrentDays(Integer noncurrentDays) {
+            setNoncurrentDays(noncurrentDays);
+            return this;
+        }
+
+        public boolean hasNoncurrentDays() {
+            return this.noncurrentDays != null;
+        }
+
+        public StorageClass getStorageClass() {
+            return storageClass;
+        }
+
+        public void setStorageClass(StorageClass storageClass) {
+            this.storageClass = storageClass;
+        }
+
+        public NoncurrentVersionStorageTransition withStrorageClass(StorageClass storageClass) {
+            setStorageClass(storageClass);
+            return this;
+        }
+    }
+
+    public static class NoncurrentVersionExpiration {
+        private Integer noncurrentDays;
+
+        public NoncurrentVersionExpiration() {
+        }
+
+        public NoncurrentVersionExpiration(Integer noncurrentDays) {
+            this.noncurrentDays = noncurrentDays;
+        }
+
+        public Integer getNoncurrentDays() {
+            return noncurrentDays;
+        }
+
+        public void setNoncurrentDays(Integer noncurrentDays) {
+            this.noncurrentDays = noncurrentDays;
+        }
+
+        public NoncurrentVersionExpiration withNoncurrentDays(Integer noncurrentDays) {
+            setNoncurrentDays(noncurrentDays);
+            return this;
+        }
+
+        public boolean hasNoncurrentDays() {
+            return this.noncurrentDays != null;
+        }
+    }
+
     private String id;
     private String prefix;
     private RuleStatus status;
     private int expirationDays;
     private Date expirationTime;
     private Date createdBeforeDate;
+    private Boolean expiredDeleteMarker;
 
     private AbortMultipartUpload abortMultipartUpload;
     private List<StorageTransition> storageTransitions = new ArrayList<StorageTransition>();
-
     private Map<String, String> tags = new HashMap<String, String>();
-    
+    private NoncurrentVersionExpiration noncurrentVersionExpiration;
+    private List<NoncurrentVersionStorageTransition> noncurrentVersionStorageTransitions =
+            new ArrayList<NoncurrentVersionStorageTransition>();
+
+
     public LifecycleRule() {
         status = RuleStatus.Unknown;
     }
@@ -313,6 +388,18 @@ public class LifecycleRule {
         return this.createdBeforeDate != null;
     }
 
+    public Boolean getExpiredDeleteMarker() {
+        return expiredDeleteMarker;
+    }
+
+    public void setExpiredDeleteMarker(Boolean expiredDeleteMarker) {
+        this.expiredDeleteMarker = expiredDeleteMarker;
+    }
+
+    public boolean hasExpiredDeleteMarker() {
+        return expiredDeleteMarker != null;
+    }
+
     public AbortMultipartUpload getAbortMultipartUpload() {
         return abortMultipartUpload;
     }
@@ -351,5 +438,30 @@ public class LifecycleRule {
 
     public boolean hasTags() {
         return this.tags != null && !tags.isEmpty();
+    }
+
+    public NoncurrentVersionExpiration getNoncurrentVersionExpiration() {
+        return noncurrentVersionExpiration;
+    }
+
+    public void setNoncurrentVersionExpiration(NoncurrentVersionExpiration noncurrentVersionExpiration) {
+        this.noncurrentVersionExpiration = noncurrentVersionExpiration;
+    }
+
+    public boolean hasNoncurrentVersionExpiration() {
+        return noncurrentVersionExpiration != null;
+    }
+
+    public List<NoncurrentVersionStorageTransition> getNoncurrentVersionStorageTransitions() {
+        return noncurrentVersionStorageTransitions;
+    }
+
+    public boolean hasNoncurrentVersionStorageTransitions() {
+        return noncurrentVersionStorageTransitions != null && !noncurrentVersionStorageTransitions.isEmpty();
+    }
+
+    public void setNoncurrentVersionStorageTransitions(List<NoncurrentVersionStorageTransition>
+                                                               noncurrentVersionStorageTransitions) {
+        this.noncurrentVersionStorageTransitions = noncurrentVersionStorageTransitions;
     }
 }

--- a/src/main/java/com/aliyun/oss/model/SetBucketLifecycleRequest.java
+++ b/src/main/java/com/aliyun/oss/model/SetBucketLifecycleRequest.java
@@ -72,10 +72,16 @@ public class SetBucketLifecycleRequest extends GenericRequest {
         int expirationTimeFlag = lifecycleRule.hasExpirationTime() ? 1 : 0;
         int expirationDaysFlag = lifecycleRule.hasExpirationDays() ? 1 : 0;
         int createdBeforeDateFlag = lifecycleRule.hasCreatedBeforeDate() ? 1 : 0;
-        int flagSum = expirationTimeFlag + expirationDaysFlag + createdBeforeDateFlag;
-        if (flagSum > 1 || (flagSum == 0 && !lifecycleRule.hasAbortMultipartUpload()
-                && !lifecycleRule.hasStorageTransition())) {
+        int expiredDeleteMarkerFlag = lifecycleRule.hasExpiredDeleteMarker() ? 1: 0;
+        int flagSum = expirationTimeFlag + expirationDaysFlag + createdBeforeDateFlag + expiredDeleteMarkerFlag;
+        if (flagSum > 1 ) {
             throw new IllegalArgumentException("Only one expiration property should be specified.");
+        }
+
+        if (flagSum == 0 && !lifecycleRule.hasAbortMultipartUpload()
+                && !lifecycleRule.hasStorageTransition() && !lifecycleRule.hasNoncurrentVersionStorageTransitions()
+                && !lifecycleRule.hasNoncurrentVersionExpiration()) {
+            throw new IllegalArgumentException("Rule has none expiration or transition specified.");
         }
 
         if (lifecycleRule.getStatus() == LifecycleRule.RuleStatus.Unknown) {

--- a/src/test/java/com/aliyun/oss/OSSClientArgCheckTest.java
+++ b/src/test/java/com/aliyun/oss/OSSClientArgCheckTest.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.aliyun.oss.internal.OSSConstants;
@@ -55,6 +56,21 @@ public class OSSClientArgCheckTest {
         
         // Legal key
         assertTrue(OSSUtils.validateObjectKey((char)9 + "" + (char)0x20 + "123_.*  中文-!@#$%^&*()_+-=;'\"~`><?/':[]|\\"));
+    }
+
+    @Test
+    public void testValidBucketName() {
+        String bucketName = "123456789012345678901234567890123456789012345678901234567890123";
+        Assert.assertTrue(OSSUtils.validateBucketName(bucketName));
+        Assert.assertFalse(OSSUtils.validateBucketName(bucketName + "4"));
+
+        bucketName = "lyz-jdifd";
+        Assert.assertTrue(OSSUtils.validateBucketName(bucketName));
+        Assert.assertFalse(OSSUtils.validateBucketName(bucketName + "dd-"));
+        Assert.assertFalse(OSSUtils.validateBucketName(bucketName + "Ldfd"));
+        Assert.assertFalse(OSSUtils.validateBucketName(bucketName + "~dd"));
+        Assert.assertFalse(OSSUtils.validateBucketName(bucketName + "_dd"));
+        Assert.assertFalse(OSSUtils.validateBucketName(bucketName + "\\dd"));
     }
 
     @Test

--- a/src/test/java/com/aliyun/oss/integrationtests/BucketLifecycleTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/BucketLifecycleTest.java
@@ -50,7 +50,7 @@ public class BucketLifecycleTest extends TestBase {
 
     @Test
     public void testNormalSetBucketLifecycle() throws ParseException {
-        final String bucketName = "normal-set-bucket-lifecycle";
+        final String bucketName = super.bucketName + "normal-set-bucket-lifecycle";
         final String ruleId0 = "delete obsoleted files";
         final String matchPrefix0 = "obsoleted0/";
         final String ruleId1 = "delete temporary files";
@@ -66,18 +66,18 @@ public class BucketLifecycleTest extends TestBase {
         
         try {
             ossClient.createBucket(bucketName);
-            
+
             SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(bucketName);
             request.AddLifecycleRule(new LifecycleRule(ruleId0, matchPrefix0, RuleStatus.Enabled, 3));
             request.AddLifecycleRule(new LifecycleRule(ruleId1, matchPrefix1, RuleStatus.Enabled, 
                     DateUtil.parseIso8601Date("2022-10-12T00:00:00.000Z")));
-            
+
             LifecycleRule rule = new LifecycleRule(ruleId2, matchPrefix2, RuleStatus.Enabled, 3);
             LifecycleRule.AbortMultipartUpload abortMultipartUpload = new LifecycleRule.AbortMultipartUpload();
             abortMultipartUpload.setExpirationDays(3);
             rule.setAbortMultipartUpload(abortMultipartUpload);
             request.AddLifecycleRule(rule);
-            
+
             rule = new LifecycleRule(ruleId3, matchPrefix3, RuleStatus.Enabled, 30);
             abortMultipartUpload = new LifecycleRule.AbortMultipartUpload();
             abortMultipartUpload.setCreatedBeforeDate(DateUtil.parseIso8601Date("2022-10-12T00:00:00.000Z"));
@@ -93,11 +93,11 @@ public class BucketLifecycleTest extends TestBase {
             storageTransitions.add(storageTransition);
             rule.setStorageTransition(storageTransitions);
             request.AddLifecycleRule(rule);
-            
+
             rule = new LifecycleRule(ruleId4, matchPrefix4, RuleStatus.Enabled);
             rule.setCreatedBeforeDate(DateUtil.parseIso8601Date("2022-10-12T00:00:00.000Z"));
             request.AddLifecycleRule(rule);
-            
+
             rule = new LifecycleRule(ruleId5, matchPrefix5, RuleStatus.Enabled);
             storageTransition = new LifecycleRule.StorageTransition();
             storageTransition.setStorageClass(StorageClass.Archive);
@@ -106,26 +106,26 @@ public class BucketLifecycleTest extends TestBase {
             storageTransitions.add(storageTransition);
             rule.setStorageTransition(storageTransitions);
             request.AddLifecycleRule(rule);
-            
+
             ossClient.setBucketLifecycle(request);
-            
+
             List<LifecycleRule> rules = ossClient.getBucketLifecycle(bucketName);
             Assert.assertEquals(rules.size(), 6);
-            
+
             LifecycleRule r0 = rules.get(0);
             Assert.assertEquals(r0.getId(), ruleId0);
             Assert.assertEquals(r0.getPrefix(), matchPrefix0);
             Assert.assertEquals(r0.getStatus(), RuleStatus.Enabled);
             Assert.assertEquals(r0.getExpirationDays(), 3);
             Assert.assertTrue(r0.getAbortMultipartUpload() == null);
-            
+
             LifecycleRule r1 = rules.get(1);
             Assert.assertEquals(r1.getId(), ruleId1);
             Assert.assertEquals(r1.getPrefix(), matchPrefix1);
             Assert.assertEquals(r1.getStatus(), RuleStatus.Enabled);
             Assert.assertEquals(DateUtil.formatIso8601Date(r1.getExpirationTime()), "2022-10-12T00:00:00.000Z");
             Assert.assertTrue(r1.getAbortMultipartUpload() == null);
-            
+
             LifecycleRule r2 = rules.get(2);
             Assert.assertEquals(r2.getId(), ruleId2);
             Assert.assertEquals(r2.getPrefix(), matchPrefix2);
@@ -133,28 +133,28 @@ public class BucketLifecycleTest extends TestBase {
             Assert.assertEquals(r2.getExpirationDays(), 3);
             Assert.assertNotNull(r2.getAbortMultipartUpload());
             Assert.assertEquals(r2.getAbortMultipartUpload().getExpirationDays(), 3);
-            
+
             LifecycleRule r3 = rules.get(3);
             Assert.assertEquals(r3.getId(), ruleId3);
             Assert.assertEquals(r3.getPrefix(), matchPrefix3);
             Assert.assertEquals(r3.getStatus(), RuleStatus.Enabled);
             Assert.assertEquals(r3.getExpirationDays(), 30);
             Assert.assertNotNull(r3.getAbortMultipartUpload());
-            Assert.assertEquals(DateUtil.formatIso8601Date(r3.getAbortMultipartUpload().getCreatedBeforeDate()), 
+            Assert.assertEquals(DateUtil.formatIso8601Date(r3.getAbortMultipartUpload().getCreatedBeforeDate()),
                     "2022-10-12T00:00:00.000Z");
             Assert.assertTrue(r3.hasStorageTransition());
             Assert.assertTrue(r3.getStorageTransition().get(0).getExpirationDays() == 10);
             Assert.assertEquals(r3.getStorageTransition().get(0).getStorageClass(), StorageClass.IA);
             Assert.assertTrue(r3.getStorageTransition().get(1).getExpirationDays() == 20);
             Assert.assertEquals(r3.getStorageTransition().get(1).getStorageClass(), StorageClass.Archive);
-            
+
             LifecycleRule r4 = rules.get(4);
             Assert.assertEquals(r4.getId(), ruleId4);
             Assert.assertEquals(r4.getPrefix(), matchPrefix4);
             Assert.assertEquals(r4.getStatus(), RuleStatus.Enabled);
             Assert.assertEquals(DateUtil.formatIso8601Date(r4.getCreatedBeforeDate()), "2022-10-12T00:00:00.000Z");
             Assert.assertTrue(r4.getAbortMultipartUpload() == null);
-            
+
             LifecycleRule r5 = rules.get(5);
             Assert.assertEquals(r5.getId(), ruleId5);
             Assert.assertEquals(r5.getPrefix(), matchPrefix5);
@@ -164,28 +164,28 @@ public class BucketLifecycleTest extends TestBase {
             Assert.assertFalse(r5.hasExpirationDays());
             Assert.assertFalse(r5.hasAbortMultipartUpload());
             Assert.assertTrue(r5.hasStorageTransition());
-            Assert.assertEquals(DateUtil.formatIso8601Date(r5.getStorageTransition().get(0).getCreatedBeforeDate()), 
+            Assert.assertEquals(DateUtil.formatIso8601Date(r5.getStorageTransition().get(0).getCreatedBeforeDate()),
                     "2022-10-12T00:00:00.000Z");
             Assert.assertEquals(r5.getStorageTransition().get(0).getStorageClass(), StorageClass.Archive);
-            
+
             // Override existing lifecycle rules
             final String nullRuleId = null;
             request.clearLifecycles();
             request.AddLifecycleRule(new LifecycleRule(nullRuleId, matchPrefix0, RuleStatus.Enabled, 7));
             ossClient.setBucketLifecycle(request);
-            
+
             waitForCacheExpiration(5);
-            
+
             rules = ossClient.getBucketLifecycle(bucketName);
             Assert.assertEquals(rules.size(), 1);
-            
+
             r0 = rules.get(0);
             Assert.assertEquals(matchPrefix0, r0.getPrefix());
             Assert.assertEquals(r0.getStatus(), RuleStatus.Enabled);
             Assert.assertEquals(r0.getExpirationDays(), 7);
-            
+
             ossClient.deleteBucketLifecycle(bucketName);
-            
+
             // Try get bucket lifecycle again
             try {
                 ossClient.getBucketLifecycle(bucketName);
@@ -202,7 +202,7 @@ public class BucketLifecycleTest extends TestBase {
     
     @Test
     public void testNormalSetBucketLifecyclWithTagging() throws ParseException {
-        final String bucketName = "normal-set-bucket-lifecycle-tagging";
+        final String bucketName = super.bucketName + "normal-set-bucket-lifecycle-tagging";
         final String ruleId0 = "delete obsoleted files";
         final String matchPrefix0 = "obsoleted0/";
         final String ruleId1 = "delete temporary files";
@@ -215,33 +215,33 @@ public class BucketLifecycleTest extends TestBase {
         final String matchPrefix4 = "temporary2/";
         final String ruleId5 = "delete temporary files(3)";
         final String matchPrefix5 = "temporary3/";
-        
+
         try {
             ossClient.createBucket(bucketName);
-            
+
             SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(bucketName);
-            
+
             Map<String, String> tags = new HashMap<String, String>(1);
             tags.put("tag1", "balabala");
             tags.put("tag2", "haha");
-            
+
             // ruleId0
             LifecycleRule rule = new LifecycleRule(ruleId0, matchPrefix0, RuleStatus.Enabled, 3);
             rule.setTags(tags);
             request.AddLifecycleRule(rule);
-            
+
             // ruleId1, unsupported tag
             rule = new LifecycleRule(ruleId1, matchPrefix1, RuleStatus.Enabled, 
                     DateUtil.parseIso8601Date("2022-10-12T00:00:00.000Z"));
             request.AddLifecycleRule(rule);
-            
+
             // ruleId2, unsupported tag
             rule = new LifecycleRule(ruleId2, matchPrefix2, RuleStatus.Enabled, 3);
             LifecycleRule.AbortMultipartUpload abortMultipartUpload = new LifecycleRule.AbortMultipartUpload();
             abortMultipartUpload.setExpirationDays(3);
             rule.setAbortMultipartUpload(abortMultipartUpload);
             request.AddLifecycleRule(rule);
-            
+
             // ruleId3, unsupported tagging
             rule = new LifecycleRule(ruleId3, matchPrefix3, RuleStatus.Enabled, 30);
             abortMultipartUpload = new LifecycleRule.AbortMultipartUpload();
@@ -258,13 +258,13 @@ public class BucketLifecycleTest extends TestBase {
             storageTransitions.add(storageTransition);
             rule.setStorageTransition(storageTransitions);
             request.AddLifecycleRule(rule);
-            
+
             // ruleId4
             rule = new LifecycleRule(ruleId4, matchPrefix4, RuleStatus.Enabled);
             rule.setCreatedBeforeDate(DateUtil.parseIso8601Date("2022-10-12T00:00:00.000Z"));
             rule.setTags(tags);
             request.AddLifecycleRule(rule);
-            
+
             // ruleId5
             rule = new LifecycleRule(ruleId5, matchPrefix5, RuleStatus.Enabled);
             storageTransition = new LifecycleRule.StorageTransition();
@@ -275,12 +275,12 @@ public class BucketLifecycleTest extends TestBase {
             rule.setStorageTransition(storageTransitions);
             rule.setTags(tags);
             request.AddLifecycleRule(rule);
-            
+
             ossClient.setBucketLifecycle(request);
-            
+
             List<LifecycleRule> rules = ossClient.getBucketLifecycle(bucketName);
             Assert.assertEquals(rules.size(), 6);
-            
+
             LifecycleRule r0 = rules.get(0);
             Assert.assertEquals(r0.getId(), ruleId0);
             Assert.assertEquals(r0.getPrefix(), matchPrefix0);
@@ -288,14 +288,14 @@ public class BucketLifecycleTest extends TestBase {
             Assert.assertEquals(r0.getExpirationDays(), 3);
             Assert.assertTrue(r0.getAbortMultipartUpload() == null);
             Assert.assertEquals(r0.getTags().size(), 2);
-            
+
             LifecycleRule r1 = rules.get(1);
             Assert.assertEquals(r1.getId(), ruleId1);
             Assert.assertEquals(r1.getPrefix(), matchPrefix1);
             Assert.assertEquals(r1.getStatus(), RuleStatus.Enabled);
             Assert.assertEquals(DateUtil.formatIso8601Date(r1.getExpirationTime()), "2022-10-12T00:00:00.000Z");
             Assert.assertTrue(r1.getAbortMultipartUpload() == null);
-            
+
             LifecycleRule r2 = rules.get(2);
             Assert.assertEquals(r2.getId(), ruleId2);
             Assert.assertEquals(r2.getPrefix(), matchPrefix2);
@@ -303,7 +303,7 @@ public class BucketLifecycleTest extends TestBase {
             Assert.assertEquals(r2.getExpirationDays(), 3);
             Assert.assertNotNull(r2.getAbortMultipartUpload());
             Assert.assertEquals(r2.getAbortMultipartUpload().getExpirationDays(), 3);
-            
+
             LifecycleRule r3 = rules.get(3);
             Assert.assertEquals(r3.getId(), ruleId3);
             Assert.assertEquals(r3.getPrefix(), matchPrefix3);
@@ -317,7 +317,7 @@ public class BucketLifecycleTest extends TestBase {
             Assert.assertEquals(r3.getStorageTransition().get(0).getStorageClass(), StorageClass.IA);
             Assert.assertTrue(r3.getStorageTransition().get(1).getExpirationDays() == 20);
             Assert.assertEquals(r3.getStorageTransition().get(1).getStorageClass(), StorageClass.Archive);
-            
+
             LifecycleRule r4 = rules.get(4);
             Assert.assertEquals(r4.getId(), ruleId4);
             Assert.assertEquals(r4.getPrefix(), matchPrefix4);
@@ -325,7 +325,7 @@ public class BucketLifecycleTest extends TestBase {
             Assert.assertEquals(DateUtil.formatIso8601Date(r4.getCreatedBeforeDate()), "2022-10-12T00:00:00.000Z");
             Assert.assertTrue(r4.getAbortMultipartUpload() == null);
             Assert.assertEquals(r4.getTags().size(), 2);
-            
+
             LifecycleRule r5 = rules.get(5);
             Assert.assertEquals(r5.getId(), ruleId5);
             Assert.assertEquals(r5.getPrefix(), matchPrefix5);
@@ -345,16 +345,26 @@ public class BucketLifecycleTest extends TestBase {
             ossClient.deleteBucket(bucketName);
         }
     }
-    
+
     @Test
     public void testUnormalSetBucketLifecycle() throws ParseException {
-        final String bucketName = "unormal-set-bucket-lifecycle";
+        final String bucketName = super.bucketName + "unormal-set-bucket-lifecycle";
         final String ruleId0 = "delete obsoleted files";
         final String matchPrefix0 = "obsoleted/";
-        
+
         try {
             ossClient.createBucket(bucketName);
-            
+
+            //set none expiration or transition
+            try {
+                final LifecycleRule r = new LifecycleRule(ruleId0, matchPrefix0, RuleStatus.Enabled);
+                SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(bucketName);
+                request.AddLifecycleRule(r);
+                Assert.fail("Rule has none expiration or transition specified, should be failed.");
+            } catch (IllegalArgumentException e) {
+                // Expected exception.
+            }
+
             // Set non-existent bucket 
             final String nonexistentBucket = "nonexistent-bucket";            
             final LifecycleRule r = new LifecycleRule(ruleId0, matchPrefix0, RuleStatus.Enabled, 3);
@@ -368,19 +378,19 @@ public class BucketLifecycleTest extends TestBase {
                 Assert.assertEquals(OSSErrorCode.NO_SUCH_BUCKET, e.getErrorCode());
                 Assert.assertTrue(e.getMessage().startsWith(NO_SUCH_BUCKET_ERR));
             }
-            
+
             // Set bucket without ownership
             final String bucketWithoutOwnership = "oss";
             try {
                 SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(bucketWithoutOwnership);
                 request.AddLifecycleRule(r);
                 ossClient.setBucketLifecycle(request);
-                
+
                 Assert.fail("Set bucket lifecycle should not be successful");
             } catch (OSSException e) {
                 Assert.assertEquals(OSSErrorCode.ACCESS_DENIED, e.getErrorCode());
             }
-            
+
             // Set length of rule id exceeding RULE_ID_MAX_LENGTH(255)
             final String ruleId256 = genRandomString(MAX_RULE_ID_LENGTH + 1);
             try {
@@ -391,19 +401,19 @@ public class BucketLifecycleTest extends TestBase {
             } catch (Exception e) {
                 Assert.assertTrue(e instanceof IllegalArgumentException);
             }
-            
+
             // Set size of lifecycle rules exceeding LIFECYCLE_RULE_MAX_LIMIT(1000)
             try {
                 SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(nonexistentBucket);
                 for (int i = 0; i < (MAX_LIFECYCLE_RULE_LIMIT + 1) ; i++) {
                     request.AddLifecycleRule(r);
                 }
-                
+
                 Assert.fail("Set bucket lifecycle should not be successful");
             } catch (Exception e) {
                 Assert.assertTrue(e instanceof IllegalArgumentException);
             }
-            
+
             // Set both rule id and prefix null
             final String nullRuleId = null;
             final String nullMatchPrefix = null;
@@ -414,7 +424,7 @@ public class BucketLifecycleTest extends TestBase {
             } catch (Exception e) {
                 Assert.fail(e.getMessage());
             }
-            
+
             // Set both expiration day and expiration time
             try {
                 SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(nonexistentBucket);
@@ -425,12 +435,12 @@ public class BucketLifecycleTest extends TestBase {
                 invalidRule.setExpirationTime(DateUtil.parseIso8601Date("2022-10-12T00:00:00.000Z"));
                 invalidRule.setExpirationDays(3);
                 request.AddLifecycleRule(invalidRule);
-                
+
                 Assert.fail("Set bucket lifecycle should not be successful");
             } catch (Exception e) {
                 Assert.assertTrue(e instanceof IllegalArgumentException);
             }
-            
+
             // Set neither expiration day nor expiration time
             try {
                 SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(nonexistentBucket);
@@ -439,12 +449,12 @@ public class BucketLifecycleTest extends TestBase {
                 invalidRule.setPrefix(matchPrefix0);
                 invalidRule.setStatus(RuleStatus.Enabled);
                 request.AddLifecycleRule(invalidRule);
-                
+
                 Assert.fail("Set bucket lifecycle should not be successful");
             } catch (Exception e) {
                 Assert.assertTrue(e instanceof IllegalArgumentException);
             }
-            
+
             // With abort multipart upload option
             try {
                 SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(nonexistentBucket);
@@ -458,12 +468,12 @@ public class BucketLifecycleTest extends TestBase {
                 abortMultipartUpload.setCreatedBeforeDate(DateUtil.parseIso8601Date("2022-10-12T00:00:00.000Z"));
                 invalidRule.setAbortMultipartUpload(abortMultipartUpload);
                 request.AddLifecycleRule(invalidRule);
-                
+
                 Assert.fail("Set bucket lifecycle should not be successful");
             } catch (Exception e) {
                 Assert.assertTrue(e instanceof IllegalArgumentException);
             }
-            
+
             // With storage transition option
             try {
                 SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(nonexistentBucket);
@@ -479,17 +489,17 @@ public class BucketLifecycleTest extends TestBase {
                 storageTransitions.add(storageTransition);
                 invalidRule.setStorageTransition(storageTransitions);
                 request.AddLifecycleRule(invalidRule);
-                
+
                 Assert.fail("Set bucket lifecycle should not be successful");
             } catch (Exception e) {
                 Assert.assertTrue(e instanceof IllegalArgumentException);
             }
-            
+
         } finally {
             ossClient.deleteBucket(bucketName);
         }
     }
-    
+
     @Test
     public void testUnormalGetBucketLifecycle() {
         // Get non-existent bucket
@@ -501,7 +511,7 @@ public class BucketLifecycleTest extends TestBase {
             Assert.assertEquals(OSSErrorCode.NO_SUCH_BUCKET, e.getErrorCode());
             Assert.assertTrue(e.getMessage().startsWith(NO_SUCH_BUCKET_ERR));
         }
-        
+
         // Get bucket without ownership
         final String bucketWithoutOwnership = "oss";
         try {
@@ -510,12 +520,12 @@ public class BucketLifecycleTest extends TestBase {
         } catch (OSSException e) {
             Assert.assertEquals(OSSErrorCode.ACCESS_DENIED, e.getErrorCode());
         }
-        
+
         // Get bucket without setting lifecycle configuration
-        final String bucketWithoutLifecycleConfiguration = "bucket-without-lifecycle-configuration";
+        final String bucketWithoutLifecycleConfiguration = super.bucketName + "bucket-without-lifecycle-configuration";
         try {
             ossClient.createBucket(bucketWithoutLifecycleConfiguration);
-            
+
             ossClient.getBucketLifecycle(bucketWithoutLifecycleConfiguration);
             Assert.fail("Get bucket lifecycle should not be successful");
         } catch (OSSException e) {
@@ -526,11 +536,11 @@ public class BucketLifecycleTest extends TestBase {
             ossClient.deleteBucket(bucketWithoutLifecycleConfiguration);
         }
     }
-    
+
     @Test
     public void testUnormalDeleteBucketLifecycle() {
         // Delete non-existent bucket
-        final String nonexistentBucket = "unormal-delete-bucket-lifecycle";
+        final String nonexistentBucket = super.bucketName + "unormal-delete-bucket-lifecycle";
         try {
             ossClient.deleteBucketLifecycle(nonexistentBucket);
             Assert.fail("Delete bucket lifecycle should not be successful");
@@ -538,7 +548,7 @@ public class BucketLifecycleTest extends TestBase {
             Assert.assertEquals(OSSErrorCode.NO_SUCH_BUCKET, e.getErrorCode());
             Assert.assertTrue(e.getMessage().startsWith(NO_SUCH_BUCKET_ERR));
         }
-        
+
         // Delete bucket without ownership
         final String bucketWithoutOwnership = "oss";
         try {
@@ -547,9 +557,9 @@ public class BucketLifecycleTest extends TestBase {
         } catch (OSSException e) {
             Assert.assertEquals(OSSErrorCode.ACCESS_DENIED, e.getErrorCode());
         }
-        
+
         // Delete bucket without setting lifecycle configuration
-        final String bucketWithoutLifecycleConfiguration = "bucket-without-lifecycle-configuration";
+        final String bucketWithoutLifecycleConfiguration = super.bucketName + "bucket-without-lifecycle-configuration";
         try {
             ossClient.createBucket(bucketWithoutLifecycleConfiguration);
             ossClient.deleteBucketLifecycle(bucketWithoutLifecycleConfiguration);
@@ -559,5 +569,4 @@ public class BucketLifecycleTest extends TestBase {
             ossClient.deleteBucket(bucketWithoutLifecycleConfiguration);
         }
     }
-    
 }

--- a/src/test/java/com/aliyun/oss/integrationtests/BucketLifecycleVersioningTest.java
+++ b/src/test/java/com/aliyun/oss/integrationtests/BucketLifecycleVersioningTest.java
@@ -1,0 +1,193 @@
+package com.aliyun.oss.integrationtests;
+
+import com.aliyun.oss.ClientConfiguration;
+import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.OSSErrorCode;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.common.auth.Credentials;
+import com.aliyun.oss.common.auth.DefaultCredentialProvider;
+import com.aliyun.oss.common.auth.DefaultCredentials;
+import com.aliyun.oss.common.utils.DateUtil;
+import com.aliyun.oss.model.LifecycleRule;
+import com.aliyun.oss.model.SetBucketLifecycleRequest;
+import com.aliyun.oss.model.StorageClass;
+import junit.framework.Assert;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.aliyun.oss.integrationtests.TestConstants.NO_SUCH_LIFECYCLE_ERR;
+import static com.aliyun.oss.integrationtests.TestUtils.waitForCacheExpiration;
+import com.aliyun.oss.model.LifecycleRule.NoncurrentVersionStorageTransition;
+import com.aliyun.oss.model.LifecycleRule.NoncurrentVersionExpiration;
+
+public class BucketLifecycleVersioningTest extends TestBase {
+    private OSSClient ossClient;
+    private String bucketName;
+    private String endpoint;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        bucketName = super.bucketName + "-lifecycle-version";
+        endpoint = "http://oss-ap-south-1.aliyuncs.com";
+
+        //create client
+        ClientConfiguration conf = new ClientConfiguration().setSupportCname(false);
+        Credentials credentials = new DefaultCredentials(TestConfig.OSS_TEST_ACCESS_KEY_ID, TestConfig.OSS_TEST_ACCESS_KEY_SECRET);
+        ossClient = new OSSClient(endpoint, new DefaultCredentialProvider(credentials), conf);
+        ossClient.createBucket(bucketName);
+    }
+
+    @Test
+    public void testLifecycleVersioning() throws ParseException {
+        final String ruleId0 = "id0";
+        final String matchPrefix0 = "prefix0/";
+
+        try {
+            SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(bucketName);
+            LifecycleRule rule = new LifecycleRule();
+            rule = new LifecycleRule(ruleId0, matchPrefix0, LifecycleRule.RuleStatus.Enabled);
+
+            // expiredDeleteMarker
+            rule.setExpiredDeleteMarker(true);
+
+            // NoncurrentVersionExpiration
+            NoncurrentVersionExpiration noncurrentVersionExpiration = new NoncurrentVersionExpiration().withNoncurrentDays(30);
+            Assert.assertTrue(noncurrentVersionExpiration.hasNoncurrentDays());
+
+            // NoncurrentVersionStorageTransition
+            NoncurrentVersionStorageTransition noncurrentVersionStorageTransition1 =
+                    new NoncurrentVersionStorageTransition().withNoncurrentDays(10).withStrorageClass(StorageClass.IA);
+            NoncurrentVersionStorageTransition noncurrentVersionStorageTransition2 =
+                    new NoncurrentVersionStorageTransition().withNoncurrentDays(20).withStrorageClass(StorageClass.Archive);
+            Assert.assertTrue(noncurrentVersionStorageTransition1.hasNoncurrentDays());
+            Assert.assertTrue(noncurrentVersionStorageTransition2.hasNoncurrentDays());
+
+            List<NoncurrentVersionStorageTransition> noncurrentVersionStorageTransitions = new ArrayList<NoncurrentVersionStorageTransition>();
+            noncurrentVersionStorageTransitions.add(noncurrentVersionStorageTransition1);
+            noncurrentVersionStorageTransitions.add(noncurrentVersionStorageTransition2);
+
+            // add rule
+            rule.setNoncurrentVersionExpiration(noncurrentVersionExpiration);
+            rule.setNoncurrentVersionStorageTransitions(noncurrentVersionStorageTransitions);
+            request.AddLifecycleRule(rule);
+
+
+            ossClient.setBucketLifecycle(request);
+
+            List<LifecycleRule> rules = ossClient.getBucketLifecycle(bucketName);
+            Assert.assertEquals(rules.size(), 1);
+            Assert.assertEquals(ruleId0, rules.get(0).getId());
+            Assert.assertEquals(matchPrefix0, rules.get(0).getPrefix());
+            Assert.assertEquals(LifecycleRule.RuleStatus.Enabled, rules.get(0).getStatus());
+            Assert.assertTrue(rules.get(0).getExpiredDeleteMarker());
+            Assert.assertEquals(30, rules.get(0).getNoncurrentVersionExpiration().getNoncurrentDays().intValue());
+            Assert.assertEquals(2, rules.get(0).getNoncurrentVersionStorageTransitions().size());
+
+            ossClient.deleteBucketLifecycle(bucketName);
+
+            // Try get bucket lifecycle again
+            try {
+                ossClient.getBucketLifecycle(bucketName);
+            } catch (OSSException e) {
+                Assert.assertEquals(OSSErrorCode.NO_SUCH_LIFECYCLE, e.getErrorCode());
+                Assert.assertTrue(e.getMessage().startsWith(NO_SUCH_LIFECYCLE_ERR));
+            }
+        } catch (OSSException e) {
+            Assert.fail(e.getMessage());
+        } finally {
+            ossClient.deleteBucket(bucketName);
+        }
+    }
+
+    @Test
+    public void testLifecycleVersionUnnormal() throws ParseException {
+        final String ruleId0 = "id0";
+        final String matchPrefix0 = "prefix0/";
+
+        //  Only one expiration property should be specified.
+        try {
+            SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(bucketName);
+            LifecycleRule rule = new LifecycleRule();
+            rule = new LifecycleRule(ruleId0, matchPrefix0, LifecycleRule.RuleStatus.Enabled);
+
+            rule.setExpirationDays(10);
+            rule.setExpiredDeleteMarker(true);
+            request.AddLifecycleRule(rule);
+            Assert.fail("Only one expiration property should be specified.");
+        } catch (IllegalArgumentException e) {
+        }
+
+        // NoncurrentVersionExpiration days < NoncurrentVersionStorageTransition days
+        try {
+            SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(bucketName);
+            LifecycleRule rule = new LifecycleRule();
+            rule = new LifecycleRule(ruleId0, matchPrefix0, LifecycleRule.RuleStatus.Enabled);
+
+            // NoncurrentVersionExpiration
+            NoncurrentVersionExpiration noncurrentVersionExpiration = new NoncurrentVersionExpiration(5);
+
+            // NoncurrentVersionStorageTransition
+            NoncurrentVersionStorageTransition noncurrentVersionStorageTransition1 =
+                    new NoncurrentVersionStorageTransition().withNoncurrentDays(10).withStrorageClass(StorageClass.IA);
+            NoncurrentVersionStorageTransition noncurrentVersionStorageTransition2 =
+                    new NoncurrentVersionStorageTransition(20, StorageClass.Archive);
+            List<NoncurrentVersionStorageTransition> noncurrentVersionStorageTransitions = new ArrayList<NoncurrentVersionStorageTransition>();
+            noncurrentVersionStorageTransitions.add(noncurrentVersionStorageTransition1);
+            noncurrentVersionStorageTransitions.add(noncurrentVersionStorageTransition2);
+
+            // add rule
+            rule.setNoncurrentVersionExpiration(noncurrentVersionExpiration);
+            rule.setNoncurrentVersionStorageTransitions(noncurrentVersionStorageTransitions);
+            request.AddLifecycleRule(rule);
+            ossClient.setBucketLifecycle(request);
+            Assert.fail("NoncurrentVersionExpiration days should not later than NoncurrentVersionStorageTransition days.");
+        } catch (OSSException e) {
+            Assert.assertEquals(e.getErrorCode(), OSSErrorCode.INVALID_ARGUMENT);
+        }
+
+        // Archive transition days < IA transition days
+        try {
+            SetBucketLifecycleRequest request = new SetBucketLifecycleRequest(bucketName);
+            LifecycleRule rule = new LifecycleRule();
+            rule = new LifecycleRule(ruleId0, matchPrefix0, LifecycleRule.RuleStatus.Enabled);
+
+            // NoncurrentVersionExpiration
+            NoncurrentVersionExpiration noncurrentVersionExpiration = new NoncurrentVersionExpiration().withNoncurrentDays(30);
+
+            // NoncurrentVersionStorageTransition
+            NoncurrentVersionStorageTransition noncurrentVersionStorageTransition1 =
+                    new NoncurrentVersionStorageTransition().withNoncurrentDays(20).withStrorageClass(StorageClass.IA);
+            NoncurrentVersionStorageTransition noncurrentVersionStorageTransition2 =
+                    new NoncurrentVersionStorageTransition().withNoncurrentDays(10).withStrorageClass(StorageClass.Archive);
+            List<NoncurrentVersionStorageTransition> noncurrentVersionStorageTransitions = new ArrayList<NoncurrentVersionStorageTransition>();
+            noncurrentVersionStorageTransitions.add(noncurrentVersionStorageTransition1);
+            noncurrentVersionStorageTransitions.add(noncurrentVersionStorageTransition2);
+
+            // add rule
+            rule.setNoncurrentVersionExpiration(noncurrentVersionExpiration);
+            rule.setNoncurrentVersionStorageTransitions(noncurrentVersionStorageTransitions);
+            request.AddLifecycleRule(rule);
+            ossClient.setBucketLifecycle(request);
+            Assert.fail("Archive transition days should not smaller than IA transition days.");
+        } catch (OSSException e) {
+            Assert.assertEquals(e.getErrorCode(), OSSErrorCode.INVALID_ARGUMENT);
+        } finally {
+            ossClient.deleteBucket(bucketName);
+        }
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        if (ossClient != null) {
+            ossClient.shutdown();
+            ossClient = null;
+        }
+        super.tearDown();
+    }
+
+}


### PR DESCRIPTION
 1, Support object versions lifecycle.
2, Fix resumable download file checkpoint filename and tmp filename with versionid if it specified.
