### PR TITLE
1、istio 弹性环境下 header 的 field key 全部被改成小写，所以在任何 header 中获取 key 为 ETag 的数据都将返回 null 值。所以想要在使用的时候获取 ETag 的值，那么就要put的时候将 etag 的值 put 进去，当然这里做了判断，见代码； 2、HttpMesssage 中的 Messsage 应该写成 Message，根据开发规范统一改成 AbstractHttpMessage； 3、在 .gitignore 添加部分忽略文件(夹).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.settings/
 .classpath
 .project
+.idea/
+aliyun-sdk-oss.iml

--- a/src/main/java/com/aliyun/oss/common/comm/AbstractHttpMessage.java
+++ b/src/main/java/com/aliyun/oss/common/comm/AbstractHttpMessage.java
@@ -19,6 +19,8 @@
 
 package com.aliyun.oss.common.comm;
 
+import com.aliyun.oss.internal.OSSHeaders;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -27,7 +29,7 @@ import java.util.Map;
 /**
  * Common class for both HTTP request and HTTP response.
  */
-public abstract class HttpMesssage {
+public abstract class AbstractHttpMessage {
 
     private Map<String, String> headers = new HashMap<String, String>();
     private InputStream content;
@@ -43,6 +45,10 @@ public abstract class HttpMesssage {
 
     public void addHeader(String key, String value) {
         this.headers.put(key, value);
+
+        if (OSSHeaders.ETAG.toLowerCase().equals(key) && this.headers.get(OSSHeaders.ETAG) == null) {
+            this.headers.put(OSSHeaders.ETAG, value);
+        }
     }
 
     public InputStream getContent() {

--- a/src/main/java/com/aliyun/oss/common/comm/RequestMessage.java
+++ b/src/main/java/com/aliyun/oss/common/comm/RequestMessage.java
@@ -30,7 +30,7 @@ import com.aliyun.oss.model.WebServiceRequest;
 /**
  * Represent HTTP requests sent to OSS.
  */
-public class RequestMessage extends HttpMesssage {
+public class RequestMessage extends AbstractHttpMessage {
 
     /* bucket name */
     private String bucket;

--- a/src/main/java/com/aliyun/oss/common/comm/ResponseMessage.java
+++ b/src/main/java/com/aliyun/oss/common/comm/ResponseMessage.java
@@ -25,7 +25,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 
 import com.aliyun.oss.internal.OSSHeaders;
 
-public class ResponseMessage extends HttpMesssage {
+public class ResponseMessage extends AbstractHttpMessage {
 
     private static final int HTTP_SUCCESS_STATUS_CODE = 200;
 

--- a/src/main/java/com/aliyun/oss/common/comm/ServiceClient.java
+++ b/src/main/java/com/aliyun/oss/common/comm/ServiceClient.java
@@ -322,7 +322,7 @@ public abstract class ServiceClient {
      * Wrapper class based on {@link HttpMessage} that represents HTTP request
      * message to OSS.
      */
-    public static class Request extends HttpMesssage {
+    public static class Request extends AbstractHttpMessage {
         private String uri;
         private HttpMethod method;
         private boolean useUrlSignature = false;

--- a/src/test/java/com/aliyun/oss/common/comm/AbstractHttpMessageTest.java
+++ b/src/test/java/com/aliyun/oss/common/comm/AbstractHttpMessageTest.java
@@ -1,0 +1,29 @@
+package com.aliyun.oss.common.comm;
+
+import com.aliyun.oss.internal.OSSHeaders;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.UUID;
+
+/**
+ * AbstractHttpMessageTest
+ *
+ * @author xiaodongli
+ * @date 2019-11-05 17:38
+ */
+public class AbstractHttpMessageTest {
+
+    @Test
+    public void addHeaderOnETagLowercaseOriginal() {
+        AbstractHttpMessage httpMessage = new ResponseMessage(null);
+
+        String value = UUID.randomUUID().toString();
+
+        httpMessage.addHeader(OSSHeaders.ETAG.toLowerCase(), value);
+
+        Assert.assertEquals(value, httpMessage.getHeaders().get(OSSHeaders.ETAG.toLowerCase()));
+        Assert.assertEquals(value, httpMessage.getHeaders().get(OSSHeaders.ETAG));
+    }
+
+}


### PR DESCRIPTION
1、istio 弹性环境下 header 的 field key 全部被改成小写，所以在任何 header 中获取 key 为 ETag 的数据都将返回 null 值。所以想要在使用的时候获取 ETag 的值，那么就要put的时候将 etag 的值 put 进去，当然这里做了判断，见代码；
2、HttpMesssage 中的 Messsage 应该写成 Message，根据开发规范统一改成 AbstractHttpMessage；
3、在 .gitignore 添加部分忽略文件(夹).