### PR TITLE
support setting domain in request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.aliyun.oss</groupId>
     <artifactId>aliyun-sdk-oss</artifactId>
-    <version>3.13.1</version>
+    <version>3.13.2</version>
     <packaging>jar</packaging>
     <name>Aliyun OSS SDK for Java</name>
     <description>The Aliyun OSS SDK for Java used for accessing Aliyun Object Storage Service</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.aliyun.oss</groupId>
     <artifactId>aliyun-sdk-oss</artifactId>
-    <version>3.13.2</version>
+    <version>3.13.1</version>
     <packaging>jar</packaging>
     <name>Aliyun OSS SDK for Java</name>
     <description>The Aliyun OSS SDK for Java used for accessing Aliyun Object Storage Service</description>

--- a/src/main/java/com/aliyun/oss/OSSClient.java
+++ b/src/main/java/com/aliyun/oss/OSSClient.java
@@ -36,7 +36,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Date;
@@ -49,6 +48,7 @@ import com.aliyun.oss.common.auth.DefaultCredentialProvider;
 import com.aliyun.oss.common.auth.ServiceSignature;
 import com.aliyun.oss.common.comm.*;
 import com.aliyun.oss.common.utils.BinaryUtil;
+import com.aliyun.oss.common.utils.CommonUtils;
 import com.aliyun.oss.common.utils.DateUtil;
 import com.aliyun.oss.internal.*;
 import com.aliyun.oss.model.*;
@@ -286,16 +286,7 @@ public class OSSClient implements OSS {
     }
 
     private URI toURI(String endpoint) throws IllegalArgumentException {
-        if (!endpoint.contains("://")) {
-            ClientConfiguration conf = this.serviceClient.getClientConfiguration();
-            endpoint = conf.getProtocol().toString() + "://" + endpoint;
-        }
-
-        try {
-            return new URI(endpoint);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException(e);
-        }
+        return CommonUtils.toURI(endpoint, this.serviceClient.getClientConfiguration().getProtocol().toString());
     }
 
     private void initOperations() {

--- a/src/main/java/com/aliyun/oss/common/utils/CommonUtils.java
+++ b/src/main/java/com/aliyun/oss/common/utils/CommonUtils.java
@@ -1,0 +1,31 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2021 All Rights Reserved.
+ */
+package com.aliyun.oss.common.utils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ *
+ * @author zhouao
+ * @version $Id: CommonUtils.java, v 0.1 2021年09月30日 2:01 PM zhouao Exp $
+ */
+public class CommonUtils {
+    public static URI toURI(String endpoint, String defaultProtocol) throws IllegalArgumentException {
+        if (StringUtils.isNullOrEmpty(endpoint)) {
+            return null;
+        }
+
+        if (!endpoint.contains("://")) {
+            endpoint = defaultProtocol + "://" + endpoint;
+        }
+
+        try {
+            return new URI(endpoint);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/src/main/java/com/aliyun/oss/common/utils/CommonUtils.java
+++ b/src/main/java/com/aliyun/oss/common/utils/CommonUtils.java
@@ -1,16 +1,29 @@
-/**
- * Alipay.com Inc.
- * Copyright (c) 2004-2021 All Rights Reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package com.aliyun.oss.common.utils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 
 /**
- *
- * @author zhouao
- * @version $Id: CommonUtils.java, v 0.1 2021年09月30日 2:01 PM zhouao Exp $
+ * Utils for common operation.
  */
 public class CommonUtils {
     public static URI toURI(String endpoint, String defaultProtocol) throws IllegalArgumentException {

--- a/src/main/java/com/aliyun/oss/internal/CORSOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/CORSOperation.java
@@ -63,7 +63,7 @@ public class CORSOperation extends OSSOperation {
         Map<String, String> parameters = new LinkedHashMap<String, String>();
         parameters.put(SUBRESOURCE_CORS, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketCORSRequest))
                 .setMethod(HttpMethod.PUT).setBucket(setBucketCORSRequest.getBucketName()).setParameters(parameters)
                 .setInputStreamWithLength(setBucketCORSRequestMarshaller.marshall(setBucketCORSRequest))
                 .setOriginalRequest(setBucketCORSRequest).build();
@@ -85,7 +85,7 @@ public class CORSOperation extends OSSOperation {
         Map<String, String> parameters = new LinkedHashMap<String, String>();
         parameters.put(SUBRESOURCE_CORS, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setParameters(parameters).setBucket(bucketName)
                 .setOriginalRequest(genericRequest).build();
 
@@ -106,7 +106,7 @@ public class CORSOperation extends OSSOperation {
         Map<String, String> parameters = new LinkedHashMap<String, String>();
         parameters.put(SUBRESOURCE_CORS, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setParameters(parameters).setBucket(bucketName)
                 .setOriginalRequest(genericRequest).build();
 
@@ -125,7 +125,7 @@ public class CORSOperation extends OSSOperation {
         ensureBucketNameValid(bucketName);
 
         @SuppressWarnings("deprecation")
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(optionsRequest))
                 .setMethod(HttpMethod.OPTIONS).setBucket(bucketName).setKey(optionsRequest.getObjectName())
                 .addHeader(OSSHeaders.ORIGIN, optionsRequest.getOrigin())
                 .addHeader(OSSHeaders.ACCESS_CONTROL_REQUEST_METHOD, optionsRequest.getRequestMethod().name())

--- a/src/main/java/com/aliyun/oss/internal/LiveChannelOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/LiveChannelOperation.java
@@ -98,7 +98,7 @@ public class LiveChannelOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(createLiveChannelRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setKey(liveChannelName).setParameters(parameters)
                 .setHeaders(headers).setInputSize(rawContent.length)
                 .setInputStream(new ByteArrayInputStream(rawContent)).setOriginalRequest(createLiveChannelRequest)
@@ -126,7 +126,7 @@ public class LiveChannelOperation extends OSSOperation {
         parameters.put(RequestParameters.SUBRESOURCE_LIVE, null);
         parameters.put(RequestParameters.SUBRESOURCE_STATUS, setLiveChannelRequest.getLiveChannelStatus().toString());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setLiveChannelRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setKey(liveChannelName).setParameters(parameters)
                 .setOriginalRequest(setLiveChannelRequest).build();
 
@@ -149,7 +149,7 @@ public class LiveChannelOperation extends OSSOperation {
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.put(RequestParameters.SUBRESOURCE_LIVE, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(liveChannelGenericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setKey(liveChannelName).setParameters(parameters)
                 .setOriginalRequest(liveChannelGenericRequest).build();
 
@@ -173,7 +173,7 @@ public class LiveChannelOperation extends OSSOperation {
         parameters.put(RequestParameters.SUBRESOURCE_LIVE, null);
         parameters.put(RequestParameters.SUBRESOURCE_COMP, RequestParameters.STAT);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(liveChannelGenericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setKey(liveChannelName).setParameters(parameters)
                 .setOriginalRequest(liveChannelGenericRequest).build();
 
@@ -196,7 +196,7 @@ public class LiveChannelOperation extends OSSOperation {
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.put(RequestParameters.SUBRESOURCE_LIVE, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(liveChannelGenericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setKey(liveChannelName).setParameters(parameters)
                 .setOriginalRequest(liveChannelGenericRequest).build();
 
@@ -233,7 +233,7 @@ public class LiveChannelOperation extends OSSOperation {
         parameters.put(RequestParameters.SUBRESOURCE_LIVE, null);
         populateListLiveChannelsRequestParameters(listLiveChannelRequest, parameters);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(listLiveChannelRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(parameters)
                 .setOriginalRequest(listLiveChannelRequest).build();
 
@@ -257,7 +257,7 @@ public class LiveChannelOperation extends OSSOperation {
         parameters.put(RequestParameters.SUBRESOURCE_LIVE, null);
         parameters.put(RequestParameters.SUBRESOURCE_COMP, RequestParameters.HISTORY);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(liveChannelGenericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setKey(liveChannelName).setParameters(parameters)
                 .setOriginalRequest(liveChannelGenericRequest).build();
 
@@ -289,7 +289,7 @@ public class LiveChannelOperation extends OSSOperation {
         parameters.put(RequestParameters.SUBRESOURCE_END_TIME, endTime.toString());
 
         String key = liveChannelName + "/" + playlistName;
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(generateVodPlaylistRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setKey(key).setParameters(parameters)
                 .setInputStream(new ByteArrayInputStream(new byte[0])).setInputSize(0)
                 .setOriginalRequest(generateVodPlaylistRequest).build();
@@ -318,7 +318,7 @@ public class LiveChannelOperation extends OSSOperation {
         parameters.put(RequestParameters.SUBRESOURCE_START_TIME, startTime.toString());
         parameters.put(RequestParameters.SUBRESOURCE_END_TIME, endTime.toString());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(getVodPlaylistRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setKey(liveChannelName).setParameters(parameters)
                 .setOriginalRequest(getVodPlaylistRequest).build();
 

--- a/src/main/java/com/aliyun/oss/internal/OSSBucketOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSBucketOperation.java
@@ -228,7 +228,7 @@ public class OSSBucketOperation extends OSSOperation {
         addOptionalHnsHeader(headers, createBucketRequest.getHnsStatus());
         addOptionalResourceGroupIdHeader(headers, createBucketRequest.getResourceGroupId());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(createBucketRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setHeaders(headers)
                 .setInputStreamWithLength(createBucketRequestMarshaller.marshall(createBucketRequest))
                 .setOriginalRequest(createBucketRequest).build();
@@ -248,7 +248,7 @@ public class OSSBucketOperation extends OSSOperation {
         assertParameterNotNull(bucketName, "bucketName");
         ensureBucketNameValid(bucketName);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setOriginalRequest(genericRequest).build();
 
         return doOperation(request, requestIdResponseParser, bucketName, null);
@@ -296,7 +296,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addOptionalResourceGroupIdHeader(headers, listBucketRequest.getResourceGroupId());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(listBucketRequest))
                 .setMethod(HttpMethod.GET).setHeaders(headers).setParameters(params).setOriginalRequest(listBucketRequest).build();
 
         return doOperation(request, listBucketResponseParser, null, null, true);
@@ -319,7 +319,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_ACL, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketAclRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(setBucketAclRequest).build();
 
@@ -340,7 +340,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_ACL, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -355,7 +355,7 @@ public class OSSBucketOperation extends OSSOperation {
         assertParameterNotNull(bucketName, "bucketName");
         ensureBucketNameValid(bucketName);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.HEAD).setBucket(bucketName).setOriginalRequest(genericRequest).build();
 
         List<ResponseHandler> reponseHandlers = new ArrayList<ResponseHandler>();
@@ -394,7 +394,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_REFERER, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketRefererRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params)
                 .setInputStreamWithLength(bucketRefererMarshaller.marshall(referer))
                 .setOriginalRequest(setBucketRefererRequest).build();
@@ -416,7 +416,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_REFERER, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -437,7 +437,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_LOCATION, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -482,7 +482,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, listObjectsRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(listObjectsRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(listObjectsRequest).build();
 
@@ -506,7 +506,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, listObjectsV2Request.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(listObjectsV2Request))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(listObjectsV2Request).build();
 
@@ -530,7 +530,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, listVersionsRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(listVersionsRequest))
             .setMethod(HttpMethod.GET).setBucket(bucketName).setHeaders(headers).setParameters(params)
             .setOriginalRequest(listVersionsRequest).build();
 
@@ -551,7 +551,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_LOGGING, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketLoggingRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params)
                 .setInputStreamWithLength(setBucketLoggingRequestMarshaller.marshall(setBucketLoggingRequest))
                 .setOriginalRequest(setBucketLoggingRequest).build();
@@ -570,7 +570,7 @@ public class OSSBucketOperation extends OSSOperation {
 
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_IMG, null);
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(putBucketImageRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(putBucketImageRequest)
                 .setInputStreamWithLength(putBucketImageRequestMarshaller.marshall(putBucketImageRequest)).build();
@@ -587,7 +587,7 @@ public class OSSBucketOperation extends OSSOperation {
 
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_IMG, null);
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
         return doOperation(request, getBucketImageResponseParser, bucketName, null, true);
@@ -604,7 +604,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_IMG, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -625,7 +625,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_STYLE, null);
         params.put(STYLE_NAME, styleName);
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(putImageStyleRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(putImageStyleRequest)
                 .setInputStreamWithLength(putImageStyleRequestMarshaller.marshall(putImageStyleRequest)).build();
@@ -642,7 +642,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_STYLE, null);
         params.put(STYLE_NAME, styleName);
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -658,7 +658,7 @@ public class OSSBucketOperation extends OSSOperation {
         params.put(SUBRESOURCE_STYLE, null);
         params.put(STYLE_NAME, styleName);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -677,7 +677,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_STYLE, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -698,7 +698,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_PROCESS_CONF, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketProcessRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params)
                 .setInputStreamWithLength(bucketImageProcessConfMarshaller.marshall(imageProcessConf))
                 .setOriginalRequest(setBucketProcessRequest).build();
@@ -717,7 +717,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_PROCESS_CONF, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -738,7 +738,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_LOGGING, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -759,7 +759,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_LOGGING, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -785,7 +785,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_WEBSITE, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketWebSiteRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params)
                 .setInputStreamWithLength(setBucketWebsiteRequestMarshaller.marshall(setBucketWebSiteRequest))
                 .setOriginalRequest(setBucketWebSiteRequest).build();
@@ -807,7 +807,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_WEBSITE, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -828,7 +828,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_WEBSITE, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -850,7 +850,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_LIFECYCLE, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketLifecycleRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params)
                 .setInputStreamWithLength(setBucketLifecycleRequestMarshaller.marshall(setBucketLifecycleRequest))
                 .setOriginalRequest(setBucketLifecycleRequest).build();
@@ -872,7 +872,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_LIFECYCLE, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -893,7 +893,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_LIFECYCLE, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -914,7 +914,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_TAGGING, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketTaggingRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params)
                 .setInputStreamWithLength(setBucketTaggingRequestMarshaller.marshall(setBucketTaggingRequest))
                 .setOriginalRequest(setBucketTaggingRequest).build();
@@ -936,7 +936,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_TAGGING, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -957,7 +957,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_TAGGING, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -979,7 +979,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.SUBRESOURCE_VRESIONING, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
             .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
             .setOriginalRequest(genericRequest).build();
 
@@ -1005,7 +1005,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketVersioningRequest))
             .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params).setHeaders(headers)
             .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
             .setOriginalRequest(setBucketVersioningRequest).build();
@@ -1030,7 +1030,7 @@ public class OSSBucketOperation extends OSSOperation {
         params.put(RequestParameters.SUBRESOURCE_REPLICATION, null);
         params.put(RequestParameters.SUBRESOURCE_COMP, RequestParameters.COMP_ADD);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(addBucketReplicationRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setParameters(params)
                 .setInputStreamWithLength(addBucketReplicationRequestMarshaller.marshall(addBucketReplicationRequest))
                 .setOriginalRequest(addBucketReplicationRequest).build();
@@ -1053,7 +1053,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.SUBRESOURCE_REPLICATION, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -1081,7 +1081,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(deleteBucketReplicationRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
                 .setOriginalRequest(deleteBucketReplicationRequest).build();
@@ -1115,7 +1115,7 @@ public class OSSBucketOperation extends OSSOperation {
         params.put(RequestParameters.SUBRESOURCE_REPLICATION_PROGRESS, null);
         params.put(RequestParameters.RULE_ID, getBucketReplicationProgressRequest.getReplicationRuleID());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(getBucketReplicationProgressRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(getBucketReplicationProgressRequest).build();
 
@@ -1137,7 +1137,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.SUBRESOURCE_REPLICATION_LOCATION, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -1161,7 +1161,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(addBucketCnameRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
                 .setOriginalRequest(addBucketCnameRequest).build();
@@ -1180,7 +1180,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.SUBRESOURCE_CNAME, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -1205,7 +1205,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(deleteBucketCnameRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
                 .setOriginalRequest(deleteBucketCnameRequest).build();
@@ -1224,7 +1224,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.SUBRESOURCE_BUCKET_INFO, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -1242,7 +1242,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.SUBRESOURCE_STAT, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -1269,7 +1269,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketStorageCapacityRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
                 .setOriginalRequest(setBucketStorageCapacityRequest).build();
@@ -1288,7 +1288,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.SUBRESOURCE_QOS, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -1315,7 +1315,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketEncryptionRequest))
             .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params)
             .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
             .setOriginalRequest(setBucketEncryptionRequest).build();
@@ -1338,7 +1338,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_ENCRYPTION, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
             .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
             .setOriginalRequest(genericRequest).build();
 
@@ -1359,7 +1359,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_ENCRYPTION, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
             .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
             .setOriginalRequest(genericRequest).build();
 
@@ -1380,7 +1380,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketPolicyRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
                 .setOriginalRequest(setBucketPolicyRequest).build();
@@ -1396,7 +1396,7 @@ public class OSSBucketOperation extends OSSOperation {
         ensureBucketNameValid(bucketName);
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_POLICY, null);
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
         return doOperation(request, getBucketPolicyResponseParser, bucketName, null, true);
@@ -1413,7 +1413,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_POLICY, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -1438,7 +1438,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketRequestPaymentRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
                 .setOriginalRequest(setBucketRequestPaymentRequest).build();
@@ -1457,7 +1457,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.SUBRESOURCE_REQUEST_PAYMENT, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -1480,7 +1480,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketQosInfoRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
                 .setOriginalRequest(setBucketQosInfoRequest).build();
@@ -1499,7 +1499,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.SUBRESOURCE_QOS_INFO, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -1517,7 +1517,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_QOS_INFO, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -1555,7 +1555,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setAsyncFetchTaskRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
                 .setOriginalRequest(setAsyncFetchTaskRequest).build();
@@ -1580,7 +1580,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         headers.put(OSSHeaders.OSS_HEADER_TASK_ID, taskId);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(getAsyncFetchTaskRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(getAsyncFetchTaskRequest).build();
 
@@ -1599,7 +1599,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.VPCIP, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint()).setParameters(params)
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(createVpcipRequest)).setParameters(params)
                 .setMethod(HttpMethod.POST).setInputStreamWithLength(createVpcipRequestMarshaller.marshall(createVpcipRequest))
                 .setOriginalRequest(createVpcipRequest).build();
 
@@ -1635,7 +1635,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.VPCIP, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(deleteVpcipRequest))
                 .setParameters(params).setMethod(HttpMethod.DELETE)
                 .setInputStreamWithLength(deleteVpcipRequestMarshaller.marshall(deleteVpcipRequest))
                 .setOriginalRequest(deleteVpcipRequest).build();
@@ -1662,7 +1662,7 @@ public class OSSBucketOperation extends OSSOperation {
         params.put(RequestParameters.SUBRESOURCE_COMP, RequestParameters.COMP_ADD);
 
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(createBucketVpcipRequest))
                 .setMethod(HttpMethod.POST).setParameters(params).setBucket(bucketName)
                 .setInputStreamWithLength(createBucketVpcipRequestMarshaller.marshall(createBucketVpcipRequest))
                 .setOriginalRequest(createBucketVpcipRequest).build();
@@ -1688,7 +1688,7 @@ public class OSSBucketOperation extends OSSOperation {
         params.put(RequestParameters.VIP, null);
         params.put(RequestParameters.SUBRESOURCE_COMP, RequestParameters.COMP_DELETE);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(deleteBucketVpcipRequest))
                 .setMethod(HttpMethod.POST).setParameters(params).setBucket(bucketName)
                 .setInputStreamWithLength(deleteBucketVpcipRequestMarshaller.marshall(vpcPolicy))
                 .setOriginalRequest(vpcPolicy).build();
@@ -1704,7 +1704,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.VIP, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params).build();
 
         return doOperation(request, listVpcPolicyResultResponseParser, bucketName, null,true);
@@ -1728,7 +1728,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketInventoryConfigurationRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setOriginalRequest(setBucketInventoryConfigurationRequest)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
@@ -1750,7 +1750,7 @@ public class OSSBucketOperation extends OSSOperation {
         params.put(SUBRESOURCE_INVENTORY, null);
         params.put(SUBRESOURCE_INVENTORY_ID, inventoryId);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(getBucketInventoryConfigurationRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(getBucketInventoryConfigurationRequest)
                 .build();
@@ -1772,7 +1772,7 @@ public class OSSBucketOperation extends OSSOperation {
             params.put(SUBRESOURCE_CONTINUATION_TOKEN, continuationToken);
         }
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(listBucketInventoryConfigurationsRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(listBucketInventoryConfigurationsRequest)
                 .build();
@@ -1793,7 +1793,7 @@ public class OSSBucketOperation extends OSSOperation {
         params.put(SUBRESOURCE_INVENTORY, null);
         params.put(SUBRESOURCE_INVENTORY_ID, inventoryId);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(deleteBucketInventoryConfigurationRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(deleteBucketInventoryConfigurationRequest).build();
 
@@ -1812,7 +1812,7 @@ public class OSSBucketOperation extends OSSOperation {
         byte[] rawContent = initiateBucketWormRequestMarshaller.marshall(initiateBucketWormRequest);
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(initiateBucketWormRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setOriginalRequest(initiateBucketWormRequest)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
@@ -1831,7 +1831,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_WORM, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest)
                 .build();
@@ -1850,7 +1850,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_WORM_ID, wormId);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(completeBucketWormRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(completeBucketWormRequest)
                 .setInputSize(0).setInputStream(new ByteArrayInputStream(new byte[0]))
@@ -1875,7 +1875,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(extendBucketWormRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setOriginalRequest(extendBucketWormRequest)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
@@ -1893,7 +1893,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_WORM, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest)
                 .build();
@@ -1918,7 +1918,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         addRequestRequiredHeaders(headers, rawContent);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketResourceGroupRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
                 .setOriginalRequest(setBucketResourceGroupRequest).build();
@@ -1937,7 +1937,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(RequestParameters.SUBRESOURCE_RESOURCE_GROUP, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -2052,7 +2052,7 @@ public class OSSBucketOperation extends OSSOperation {
 
         byte[] rawContent = putBucketTransferAccelerationRequestMarshaller.marshall(setBucketTransferAccelerationRequest);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setBucketTransferAccelerationRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(setBucketTransferAccelerationRequest).setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent)).build();
 
@@ -2069,7 +2069,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_TRANSFER_ACCELERATION, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -2085,7 +2085,7 @@ public class OSSBucketOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_TRANSFER_ACCELERATION, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 

--- a/src/main/java/com/aliyun/oss/internal/OSSMultipartOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSMultipartOperation.java
@@ -133,7 +133,7 @@ public class OSSMultipartOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, abortMultipartUploadRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(abortMultipartUploadRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(parameters)
                 .setOriginalRequest(abortMultipartUploadRequest).build();
 
@@ -176,7 +176,7 @@ public class OSSMultipartOperation extends OSSOperation {
             }
         });
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(completeMultipartUploadRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setKey(key).setHeaders(headers)
                 .setParameters(parameters)
                 .setInputStreamWithLength(
@@ -241,7 +241,7 @@ public class OSSMultipartOperation extends OSSOperation {
         // parameters
         // to request body. Set HttpRequestFactory#createHttpRequest for
         // details.
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(initiateMultipartUploadRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
                 .setInputStream(new ByteArrayInputStream(new byte[0])).setInputSize(0)
                 .setOriginalRequest(initiateMultipartUploadRequest).build();
@@ -268,7 +268,7 @@ public class OSSMultipartOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, listMultipartUploadsRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(listMultipartUploadsRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(listMultipartUploadsRequest).build();
 
@@ -299,7 +299,7 @@ public class OSSMultipartOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, listPartsRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(listPartsRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(listPartsRequest).build();
 
@@ -351,7 +351,7 @@ public class OSSMultipartOperation extends OSSOperation {
         params.put(PART_NUMBER, Integer.toString(partNumber));
         params.put(UPLOAD_ID, uploadId);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(uploadPartRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setKey(key).setParameters(params).setHeaders(headers)
                 .setInputStream(repeatableInputStream).setInputSize(uploadPartRequest.getPartSize())
                 .setUseChunkEncoding(uploadPartRequest.isUseChunkEncoding()).setOriginalRequest(uploadPartRequest)
@@ -421,7 +421,7 @@ public class OSSMultipartOperation extends OSSOperation {
         params.put(PART_NUMBER, Integer.toString(partNumber));
         params.put(UPLOAD_ID, uploadId);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(uploadPartCopyRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setKey(key).setParameters(params).setHeaders(headers)
                 .setOriginalRequest(uploadPartCopyRequest).build();
 

--- a/src/main/java/com/aliyun/oss/internal/OSSObjectOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSObjectOperation.java
@@ -218,7 +218,7 @@ public class OSSObjectOperation extends OSSOperation {
         populateRequestPayerHeader(headers, createSelectObjectMetadataRequest.getRequestPayer());
 
         byte[] content = createSelectObjectMetadataRequestMarshaller.marshall(createSelectObjectMetadataRequest);
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(createSelectObjectMetadataRequest))
                 .setMethod(HttpMethod.POST).setInputSize(content.length).setInputStream(new ByteArrayInputStream(content))
                 .setBucket(bucketName).setKey(key).setHeaders(headers).setOriginalRequest(genericRequest)
                 .build();
@@ -290,7 +290,7 @@ public class OSSObjectOperation extends OSSOperation {
         byte[] content = selectObjectRequestMarshaller.marshall(selectObjectRequest);
 
         headers.put(HttpHeaders.CONTENT_MD5, BinaryUtil.toBase64String(BinaryUtil.calculateMd5(content)));
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(selectObjectRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setKey(key).setHeaders(headers)
                 .setInputSize(content.length).setInputStream(new ByteArrayInputStream(content))
                 .setParameters(params).setOriginalRequest(selectObjectRequest).build();
@@ -351,7 +351,7 @@ public class OSSObjectOperation extends OSSOperation {
                 params.put(RequestParameters.SUBRESOURCE_PROCESS, process);
             }
 
-            request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+            request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(getObjectRequest))
                     .setMethod(HttpMethod.GET).setBucket(bucketName).setKey(key).setHeaders(headers)
                     .setParameters(params).setOriginalRequest(getObjectRequest).build();
         } else {
@@ -443,7 +443,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, genericRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.HEAD).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -474,7 +474,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, genericRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.HEAD).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -491,7 +491,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateCopyObjectHeaders(copyObjectRequest, headers);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(copyObjectRequest))
                 .setMethod(HttpMethod.PUT).setBucket(copyObjectRequest.getDestinationBucketName())
                 .setKey(copyObjectRequest.getDestinationKey()).setHeaders(headers).setOriginalRequest(copyObjectRequest)
                 .build();
@@ -518,7 +518,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, genericRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.DELETE).setBucket(bucketName).setKey(key).setHeaders(headers).setOriginalRequest(genericRequest)
                 .build();
 
@@ -548,7 +548,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, deleteVersionRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(deleteVersionRequest))
             .setMethod(HttpMethod.DELETE).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
             .setOriginalRequest(deleteVersionRequest).build();
 
@@ -574,7 +574,7 @@ public class OSSObjectOperation extends OSSOperation {
         addDeleteObjectsRequiredHeaders(headers, rawContent);
         addDeleteObjectsOptionalHeaders(headers, deleteObjectsRequest);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(deleteObjectsRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setParameters(params).setHeaders(headers)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
                 .setOriginalRequest(deleteObjectsRequest).build();
@@ -603,7 +603,7 @@ public class OSSObjectOperation extends OSSOperation {
 
         populateRequestPayerHeader(headers, deleteVersionsRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(deleteVersionsRequest))
             .setMethod(HttpMethod.POST).setBucket(bucketName).setParameters(params).setHeaders(headers)
             .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
             .setOriginalRequest(deleteVersionsRequest).build();
@@ -643,7 +643,7 @@ public class OSSObjectOperation extends OSSOperation {
             params.put(RequestParameters.SUBRESOURCE_VRESION_ID, headObjectRequest.getVersionId());
         }
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(headObjectRequest))
                 .setMethod(HttpMethod.HEAD).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(headObjectRequest).build();
 
@@ -675,7 +675,7 @@ public class OSSObjectOperation extends OSSOperation {
             params.put(RequestParameters.SUBRESOURCE_VRESION_ID, setObjectAclRequest.getVersionId());
         }
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setObjectAclRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setKey(key).setParameters(params).setHeaders(headers)
                 .setOriginalRequest(setObjectAclRequest).build();
 
@@ -703,7 +703,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, genericRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -740,7 +740,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, genericRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
                 .setInputStream(new ByteArrayInputStream(content)).setInputSize(content.length)
                 .setOriginalRequest(genericRequest).build();
@@ -769,7 +769,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, setObjectTaggingRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(setObjectTaggingRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
                 .setInputStreamWithLength(setBucketTaggingRequestMarshaller.marshall(setObjectTaggingRequest))
                 .setOriginalRequest(setObjectTaggingRequest).build();
@@ -798,7 +798,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, genericRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
         
@@ -826,7 +826,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, genericRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
             .setMethod(HttpMethod.DELETE).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
             .setOriginalRequest(genericRequest).build();
 
@@ -850,7 +850,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, genericRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(genericRequest))
                 .setMethod(HttpMethod.GET).setBucket(bucketName).setKey(symlink).setHeaders(headers).setParameters(params)
                 .setOriginalRequest(genericRequest).build();
 
@@ -899,7 +899,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_SYMLINK, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(createSymlinkRequest))
                 .setMethod(HttpMethod.PUT).setBucket(bucketName).setKey(symlink).setHeaders(headers)
                 .setParameters(params).setOriginalRequest(createSymlinkRequest).build();
 
@@ -928,7 +928,7 @@ public class OSSObjectOperation extends OSSOperation {
 
         byte[] rawContent = processObjectRequestMarshaller.marshall(processObjectRequest);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(processObjectRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setKey(key).setHeaders(headers).setParameters(params)
                 .setInputSize(rawContent.length).setInputStream(new ByteArrayInputStream(rawContent))
                 .setOriginalRequest(processObjectRequest).build();
@@ -994,7 +994,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> headers = new HashMap<String, String>();
         populateRequestPayerHeader(headers, createDirectoryRequest.getRequestPayer());
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(createDirectoryRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setKey(directory).setParameters(params).setHeaders(headers)
                 .setInputStream(new ByteArrayInputStream(new byte[0])).setInputSize(0)
                 .setOriginalRequest(createDirectoryRequest).build();
@@ -1019,7 +1019,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_DIR_DELETE, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(deleteDirectoryRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setKey(directoryName).setParameters(params).setHeaders(headers)
                 .setInputStream(new ByteArrayInputStream(new byte[0])).setInputSize(0)
                 .setOriginalRequest(deleteDirectoryRequest).build();
@@ -1047,7 +1047,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> params = new HashMap<String, String>();
         params.put(SUBRESOURCE_RENAME, null);
 
-        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage request = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(renameObjectRequest))
                 .setMethod(HttpMethod.POST).setBucket(bucketName).setKey(destObject).setParameters(params).setHeaders(headers)
                 .setInputStream(new ByteArrayInputStream(new byte[0])).setInputSize(0)
                 .setOriginalRequest(renameObjectRequest).build();
@@ -1178,7 +1178,7 @@ public class OSSObjectOperation extends OSSOperation {
         Map<String, String> params = new LinkedHashMap<String, String>();
         populateWriteObjectParams(mode, originalRequest, params);
 
-        RequestMessage httpRequest = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint())
+        RequestMessage httpRequest = new OSSRequestMessageBuilder(getInnerClient()).setEndpoint(getEndpoint(originalRequest))
                 .setMethod(WriteMode.getMappingMethod(mode)).setBucket(bucketName).setKey(key).setHeaders(headers)
                 .setParameters(params).setInputStream(repeatableInputStream)
                 .setInputSize(determineInputStreamLength(repeatableInputStream, metadata.getContentLength()))

--- a/src/main/java/com/aliyun/oss/internal/OSSOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSOperation.java
@@ -66,6 +66,11 @@ public abstract class OSSOperation {
         return endpoint;
     }
 
+    public URI getEndpoint(WebServiceRequest request) {
+        URI endpointInRequest = request.getEndPoint(this.client.getClientConfiguration().getProtocol().toString());
+        return endpointInRequest != null ? endpointInRequest : endpoint;
+    }
+
     public void setEndpoint(URI endpoint) {
         this.endpoint = URI.create(endpoint.toString());
     }

--- a/src/main/java/com/aliyun/oss/model/WebServiceRequest.java
+++ b/src/main/java/com/aliyun/oss/model/WebServiceRequest.java
@@ -19,12 +19,18 @@
 
 package com.aliyun.oss.model;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import com.aliyun.oss.ClientConfiguration;
+import com.aliyun.oss.common.utils.StringUtils;
 import com.aliyun.oss.event.ProgressListener;
+import com.aliyun.oss.internal.OSSUtils;
 
 public abstract class WebServiceRequest {
 
@@ -37,8 +43,11 @@ public abstract class WebServiceRequest {
     //We enable INFO and WARNING logs by default.
     private boolean logEnabled = true;
 
+    //If request is set endPoint ,it will overwrite endpoint  set in ossclient
+    private String endPoint;
+
     private Map<String, String> parameters = new LinkedHashMap<String, String>();
-    private Map<String, String> headers = new LinkedHashMap<String, String>();
+    private Map<String, String> headers    = new LinkedHashMap<String, String>();
 
     private Set<String> additionalHeaderNames = new HashSet<String>();
 
@@ -99,5 +108,28 @@ public abstract class WebServiceRequest {
 
     public void setLogEnabled(boolean logEnabled) {
         this.logEnabled = logEnabled;
+    }
+
+    public URI getEndPoint(String defaultProtocol) {
+        if (com.aliyuncs.utils.StringUtils.isEmpty(endPoint)) {
+            return null;
+        }
+
+        if (!endPoint.contains("://")) {
+            endPoint = defaultProtocol + "://" + endPoint;
+        }
+
+        URI endPointURI;
+        try {
+            endPointURI = new URI(endPoint);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+        OSSUtils.ensureEndpointValid(endPointURI.getHost());
+        return endPointURI;
+    }
+
+    public void setEndPoint(String endPoint) {
+        this.endPoint = endPoint;
     }
 }

--- a/src/main/java/com/aliyun/oss/model/WebServiceRequest.java
+++ b/src/main/java/com/aliyun/oss/model/WebServiceRequest.java
@@ -19,18 +19,14 @@
 
 package com.aliyun.oss.model;
 
+import com.aliyun.oss.common.utils.CommonUtils;
+import com.aliyun.oss.event.ProgressListener;
+
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-
-import com.aliyun.oss.ClientConfiguration;
-import com.aliyun.oss.common.utils.StringUtils;
-import com.aliyun.oss.event.ProgressListener;
-import com.aliyun.oss.internal.OSSUtils;
 
 public abstract class WebServiceRequest {
 
@@ -111,22 +107,7 @@ public abstract class WebServiceRequest {
     }
 
     public URI getEndPoint(String defaultProtocol) {
-        if (com.aliyuncs.utils.StringUtils.isEmpty(endPoint)) {
-            return null;
-        }
-
-        if (!endPoint.contains("://")) {
-            endPoint = defaultProtocol + "://" + endPoint;
-        }
-
-        URI endPointURI;
-        try {
-            endPointURI = new URI(endPoint);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException(e);
-        }
-        OSSUtils.ensureEndpointValid(endPointURI.getHost());
-        return endPointURI;
+        return CommonUtils.toURI(endPoint,defaultProtocol);
     }
 
     public void setEndPoint(String endPoint) {

--- a/src/test/java/com/aliyun/oss/common/comm/CommonUtilsTest.java
+++ b/src/test/java/com/aliyun/oss/common/comm/CommonUtilsTest.java
@@ -45,7 +45,7 @@ public class CommonUtilsTest {
         assertEquals("https://oss-cn-hangzhou.aliyuncs.com", res.toString());
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testToURI3() {
         String endpoint = "oss-cn-hangzhou.aliyuncs.com";
         String defaultProtocol = "";
@@ -54,12 +54,12 @@ public class CommonUtilsTest {
         assertEquals("https://oss-cn-hangzhou.aliyuncs.com", res.toString());
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testToURI4() {
         String endpoint = null;
         String defaultProtocol = "http";
 
         URI res = CommonUtils.toURI(endpoint, defaultProtocol);
-        assertEquals("https://oss-cn-hangzhou.aliyuncs.com", res.toString());
+        assertEquals(null, res);
     }
 }

--- a/src/test/java/com/aliyun/oss/common/comm/CommonUtilsTest.java
+++ b/src/test/java/com/aliyun/oss/common/comm/CommonUtilsTest.java
@@ -1,7 +1,22 @@
-/**
- * Alipay.com Inc.
- * Copyright (c) 2004-2021 All Rights Reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package com.aliyun.oss.common.comm;
 
 import com.aliyun.oss.common.utils.CommonUtils;
@@ -11,11 +26,6 @@ import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- *
- * @author zhouao
- * @version $Id: CommonUtilsTest.java, v 0.1 2021年09月30日 2:09 PM zhouao Exp $
- */
 public class CommonUtilsTest {
     @Test
     public void testToURI() {

--- a/src/test/java/com/aliyun/oss/common/comm/CommonUtilsTest.java
+++ b/src/test/java/com/aliyun/oss/common/comm/CommonUtilsTest.java
@@ -1,0 +1,55 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2021 All Rights Reserved.
+ */
+package com.aliyun.oss.common.comm;
+
+import com.aliyun.oss.common.utils.CommonUtils;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author zhouao
+ * @version $Id: CommonUtilsTest.java, v 0.1 2021年09月30日 2:09 PM zhouao Exp $
+ */
+public class CommonUtilsTest {
+    @Test
+    public void testToURI() {
+        String endpoint = "http://oss-cn-hangzhou.aliyuncs.com";
+        String defaultProtocol = "https";
+
+        URI res = CommonUtils.toURI(endpoint, defaultProtocol);
+        assertEquals(endpoint, res.toString());
+    }
+
+    @Test
+    public void testToURI2() {
+        String endpoint = "oss-cn-hangzhou.aliyuncs.com";
+        String defaultProtocol = "https";
+
+        URI res = CommonUtils.toURI(endpoint, defaultProtocol);
+        assertEquals("https://oss-cn-hangzhou.aliyuncs.com", res.toString());
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testToURI3() {
+        String endpoint = "oss-cn-hangzhou.aliyuncs.com";
+        String defaultProtocol = "";
+
+        URI res = CommonUtils.toURI(endpoint, defaultProtocol);
+        assertEquals("https://oss-cn-hangzhou.aliyuncs.com", res.toString());
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testToURI4() {
+        String endpoint = null;
+        String defaultProtocol = "http";
+
+        URI res = CommonUtils.toURI(endpoint, defaultProtocol);
+        assertEquals("https://oss-cn-hangzhou.aliyuncs.com", res.toString());
+    }
+}

--- a/src/test/java/com/aliyun/oss/common/comm/OSSClientTest.java
+++ b/src/test/java/com/aliyun/oss/common/comm/OSSClientTest.java
@@ -30,6 +30,8 @@ import com.aliyun.oss.*;
 import com.aliyun.oss.common.auth.Credentials;
 import com.aliyun.oss.common.auth.CredentialsProvider;
 import com.aliyun.oss.internal.OSSConstants;
+import com.aliyun.oss.internal.RequestParameters;
+import com.aliyun.oss.model.GetObjectRequest;
 import junit.framework.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -87,7 +89,7 @@ public class OSSClientTest {
             assertTrue(true);
         }
     }
-    
+
     @Test
     public void testProxyHost() {
         String endpoint = "http://oss-cn-hangzhou.aliyuncs.com";
@@ -367,6 +369,31 @@ public class OSSClientTest {
         } catch (Exception e1) {
             Assert.fail("should be failed here.");
         }
+    }
+
+    @Test
+    public void testEndpoint2() {
+        String endpoint = "http://oss-cn-hangzhou.aliyuncs.com";
+        String endpoint2 = "http://oss-cn-shanghai.aliyuncs.com";
+
+        String accessKeyId = "accessKeyId";
+        String accessKeySecret = "accessKeySecret";
+
+        ClientBuilderConfiguration conf = new ClientBuilderConfiguration();
+        conf.setProxyHost(endpoint);
+        conf.setProxyPort(80);
+        conf.setProxyUsername("user");
+        conf.setProxyPassword("passwd");
+
+        OSS ossClient = new OSSClientBuilder().build(endpoint, accessKeyId, accessKeySecret, conf);
+
+        GetObjectRequest request= new GetObjectRequest("bucket","objedct");
+        request.setEndPoint(endpoint2);
+        ossClient.getObject(request);
+        ossClient.shutdown();
+
+
+
     }
 }
 


### PR DESCRIPTION
OSS offers datalake accelerator domain now ,it cloud make object download more faster. In some situations, clients may want to use normal domain to upload objects, and  use datalake accelerator domain to download objects. In order to meet customer demand，we  add  "set domian" feature in Request Class. Clients can set a domain  which is different from normal domain set in ossclient for a singe request.