### PR TITLE
Bump jdom2 from 2.0.6 to 2.0.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.jdom</groupId>
             <artifactId>jdom2</artifactId>
-            <version>2.0.6</version>
+            <version>2.0.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jettison</groupId>


### PR DESCRIPTION
Should fix CVE-2021-33813

See https://github.com/aliyun/aliyun-oss-java-sdk/issues/395