### PR TITLE
Bump httpclient from 4.4.1 to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.4.1</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.jdom</groupId>


### PR DESCRIPTION
This bumps httpclient from 4.4.1 to 4.5.13 to fix [the vulnerability](https://github.com/advisories/GHSA-7r82-7xv7-xcpj)