### PR TITLE
fix(sec): upgrade org.codehaus.jettison:jettison to 1.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
-            <version>1.5.1</version>
+            <version>1.5.2</version>
         </dependency>
         <dependency>
             <groupId>com.aliyun</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.codehaus.jettison:jettison 1.5.1
- [CVE-2022-40150](https://www.oscs1024.com/hd/CVE-2022-40150)


### What did I do？
Upgrade org.codehaus.jettison:jettison from 1.5.1 to 1.5.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS