### PR TITLE
Fix recursion case caused by multi retries

### DIFF
--- a/src/main/java/com/aliyun/oss/common/comm/ServiceClient.java
+++ b/src/main/java/com/aliyun/oss/common/comm/ServiceClient.java
@@ -124,6 +124,7 @@ public abstract class ServiceClient {
                     if (requestContent != null && requestContent.markSupported()) {
                         try {
                             requestContent.reset();
+                            request.setContent(requestContent);
                         } catch (IOException ex) {
                             logException("Failed to reset the request input stream: ", ex);
                             throw new ClientException("Failed to reset the request input stream: ", ex);


### PR DESCRIPTION
Request retry causes recursive `InpustStream.read` which may result in redundant CRC calculation or something like that.