### PR TITLE
Fixed a credential refresh edge case

### DIFF
--- a/src/main/java/com/aliyun/oss/common/auth/STSAssumeRoleSessionCredentialsProvider.java
+++ b/src/main/java/com/aliyun/oss/common/auth/STSAssumeRoleSessionCredentialsProvider.java
@@ -84,7 +84,10 @@ public class STSAssumeRoleSessionCredentialsProvider implements CredentialsProvi
         if (credentials == null || credentials.willSoonExpire()) {
             synchronized (this) {
                 if (credentials == null || credentials.willSoonExpire()) {
-                    credentials = getNewSessionCredentials();
+                    BasicCredentials newCredentials = getNewSessionCredentials();
+                    if(newCredentials != null) {
+                        credentials = newCredentials;
+                    }
                 }
             }
         }


### PR DESCRIPTION
The current code treats "no cached credentials" and "credentials about to expire" as the same condition. The problem is that it tries to refresh the soon-to-expire credentials, and blindly overrides the current value. This is a problem because the refresh can (and has failed on us), while the existing credentials would still otherwise have been valid. It overwrites the existing "good" credentials with a null value, when it didn't need to. 

This pull request changes it so it only replaces the existing credentials only if the new credentials are actually valid.