### PR TITLE
doesBucketExists方法被设计为会抛出OSSException异常，但是在catch之后，没有再次抛出异常，该异常被吞没。

### DIFF
--- a/src/main/java/com/aliyun/oss/internal/OSSBucketOperation.java
+++ b/src/main/java/com/aliyun/oss/internal/OSSBucketOperation.java
@@ -314,6 +314,7 @@ public class OSSBucketOperation extends OSSOperation {
             if (oe.getErrorCode().equals(OSSErrorCode.NO_SUCH_BUCKET)) {
                 return false;
             }
+            throw oe;
         }
         return true;
     }


### PR DESCRIPTION
## PR类型
  Bug修复

## 变更描述
  本次修改主要增加了com.aliyun.oss.internal.OSSBucketOperation#doesBucketExists方法捕获异常的抛出。
  
### 动机与背景
  doesBucketExists方法被设计为会抛出OSSException异常，但是在catch之后，没有再次抛出异常，会导致该异常被吞没。

### 影响范围
  影响bucket的判断bucket是否存在的api。
  不涉及数据。
  用户使用不影响使用，不改变文档的描述。

## 检查清单
- [ x ] 代码遵循了项目的编码风格规范。
- [ x ] 已对新增抛出异常的代码进行了调用测试。
- [ x ] 变更不会引入已知的新Bug或安全风险。